### PR TITLE
유저 프로필 도메인 메소드 수정

### DIFF
--- a/src/user/domain/profile.domain.ts
+++ b/src/user/domain/profile.domain.ts
@@ -109,6 +109,7 @@ export class MakerProfile implements IMakerProfile {
 
   get() {
     return {
+      userId: this.userId,
       image: this.image,
       serviceArea: this.serviceArea,
       serviceTypes: this.serviceTypes,


### PR DESCRIPTION
## 작업한 이슈 번호

- close #35 

## 작업 사항 설명

유저 maker Profile 도메인에 get 메소드 반환값에 누락된 것이 있어 오류가 발생하는 이슈가 있어 수정합니다.

## 작업 사항

- [x] 오류 해결: get 메소드 반환값에 userId 필드 추가

## 기타

- 확인하시면 머지해 주세요~!
