### PR TITLE
Dreamer의 본인 플랜의 견적 조회 api 구현

### DIFF
--- a/httpTest/quote.http
+++ b/httpTest/quote.http
@@ -8,7 +8,7 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJhMmIzY
 GET http://localhost:4000/quotes/be7f1e1c-5192-4fa7-9e5e-8e228a8d8038
 #유저가 삭제됐을 때 테스트
 ###
-GET http://localhost:4000/plans/d7a56f8d-94b9-4b9d-8bdf-3b6295a3b3b4/quotes?status=PENDING
+GET http://localhost:4000/plans/4f51184e-72fb-4dd0-acd9-a4dd3ba905/quotes?pageSize=10
 Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJhMWIyYzNkNC1lNWY2LTc4OTAtYWJjZC0xMjM0NTY3ODkwZWYiLCJpYXQiOjE3MzY0ODgwOTgsImV4cCI6MTczNzA5Mjg5OH0.3FF1yKyL9m703ZeWsBtu3HcmmXywsqweOn7WabnS8bY
 #Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJiMmMzZDRlNS1mNjc4LTkwYWItY2RlZi0yMzQ1Njc4OTAxYWIiLCJpYXQiOjE3MzY0ODgyMDksImV4cCI6MTczNzA5MzAwOX0.wvas5nApZhmBgbW71mh5gOs9RFHvrfEEFuf6cghQXrw
 #GetByDreamer 테스트

--- a/httpTest/quote.http
+++ b/httpTest/quote.http
@@ -8,3 +8,8 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJhMmIzY
 GET http://localhost:4000/quotes/be7f1e1c-5192-4fa7-9e5e-8e228a8d8038
 #유저가 삭제됐을 때 테스트
 ###
+GET http://localhost:4000/plans/d7a56f8d-94b9-4b9d-8bdf-3b6295a3b3b4/quotes?status=PENDING
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJhMWIyYzNkNC1lNWY2LTc4OTAtYWJjZC0xMjM0NTY3ODkwZWYiLCJpYXQiOjE3MzY0ODgwOTgsImV4cCI6MTczNzA5Mjg5OH0.3FF1yKyL9m703ZeWsBtu3HcmmXywsqweOn7WabnS8bY
+#Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJiMmMzZDRlNS1mNjc4LTkwYWItY2RlZi0yMzQ1Njc4OTAxYWIiLCJpYXQiOjE3MzY0ODgyMDksImV4cCI6MTczNzA5MzAwOX0.wvas5nApZhmBgbW71mh5gOs9RFHvrfEEFuf6cghQXrw
+#GetByDreamer 테스트
+###

--- a/httpTest/user.http
+++ b/httpTest/user.http
@@ -57,7 +57,7 @@ POST http://localhost:4000/user/login
 Content-Type: application/json
 
 {
-	"email": "maker2@test.com",
+	"email": "dreamer2@test.com",
 	"password": "12345678"
 }
 ###

--- a/src/common/enums/error.message.ts
+++ b/src/common/enums/error.message.ts
@@ -25,6 +25,9 @@ const enum ErrorMessage {
 
   QUOTE_NOT_FOUND = '해당 견적서를 찾을 수 없습니다.',
   QUOTE_FORBIDDEN_ID = '해당 견적서의 Maker와 Dreamer만 조회할 수 있습니다.',
+  QUOTE_FORBIDDEN_MAKER = '해당 견적서의 Maker만 조회할 수 있습니다.',
+  QUOTE_FORBIDDEN_DREAMER = '해당 견적서의 Dreamer만 조회할 수 있습니다.',
+  QUOTE_BAD_REQUEST_CONFIRMED = '해당 api는 CONFIRMED 입력을 받지 않습니다.',
 
   INTERNAL_SERVER_ERROR = '내부 서버 오류'
 }

--- a/src/common/enums/error.message.ts
+++ b/src/common/enums/error.message.ts
@@ -27,7 +27,6 @@ const enum ErrorMessage {
   QUOTE_FORBIDDEN_ID = '해당 견적서의 Maker와 Dreamer만 조회할 수 있습니다.',
   QUOTE_FORBIDDEN_MAKER = '해당 견적서의 Maker만 조회할 수 있습니다.',
   QUOTE_FORBIDDEN_DREAMER = '해당 견적서의 Dreamer만 조회할 수 있습니다.',
-  QUOTE_BAD_REQUEST_CONFIRMED = '해당 api는 CONFIRMED 입력을 받지 않습니다.',
 
   INTERNAL_SERVER_ERROR = '내부 서버 오류'
 }

--- a/src/common/filters/globalExceptionFilter.ts
+++ b/src/common/filters/globalExceptionFilter.ts
@@ -12,7 +12,7 @@ class GlobalExceptionFilter implements ExceptionFilter {
 
     let status = HttpStatus.INTERNAL_SERVER_ERROR;
     let message = 'Internal server error';
-    console.log(exception);
+
     if (exception instanceof CustomError) {
       status = exception.statusCode;
       message = exception.message;

--- a/src/common/types/status.type.ts
+++ b/src/common/types/status.type.ts
@@ -1,1 +1,8 @@
 export type Status = 'PENDING' | 'CONFIRMED' | 'COMPLETED' | 'OVERDUE';
+
+export enum StatusEnum {
+  PENDING = 'PENDING',
+  CONFIRMED = 'CONFIRMED',
+  COMPLETED = 'COMPLETED',
+  OVERDUE = 'OVERDUE'
+}

--- a/src/plan/plan.controller.ts
+++ b/src/plan/plan.controller.ts
@@ -9,6 +9,8 @@ import CreatePlanDataDTO from './type/createPlanData.dto';
 import CreatePlanData from './type/createPlanData.interface';
 import UpdatePlanData from './type/updatePlanData.interface';
 import UpdateAssignDataDTO from './type/updateAssignData.dto';
+import { QuoteQueryOptionsByDreamerDTO } from 'src/quote/type/quoteQueryOptions.interface';
+import QuoteToClientProperties from 'src/quote/type/quoteToClientProperties.interface';
 
 @Controller('plans')
 export default class PlanController {
@@ -27,6 +29,17 @@ export default class PlanController {
   async getPlanById(@Param('id') id: string): Promise<Plan> {
     const plan = await this.planService.getPlanById(id);
     return plan;
+  }
+
+  @Get(':planId/quotes')
+  async getQuotesByPlanId(
+    @User() userId: string,
+    @Param('planId') planId: string,
+    @Query() options: QuoteQueryOptionsByDreamerDTO
+  ): Promise<{ totalCount: number; list: QuoteToClientProperties[] }> {
+    const serviceOptions = { ...options, planId };
+    const { totalCount, list } = await this.planService.getQuotesByPlanId(serviceOptions, userId);
+    return { totalCount, list };
   }
 
   @Post()

--- a/src/plan/plan.module.ts
+++ b/src/plan/plan.module.ts
@@ -3,9 +3,10 @@ import PlanController from './plan.controller';
 import PlanRepository from './plan.repository';
 import PlanService from './plan.service';
 import UserModule from 'src/user/user.module';
+import QuoteModule from 'src/quote/quote.module';
 
 @Module({
-  imports: [UserModule],
+  imports: [UserModule, QuoteModule],
   controllers: [PlanController],
   providers: [PlanRepository, PlanService]
 })

--- a/src/plan/plan.service.ts
+++ b/src/plan/plan.service.ts
@@ -11,12 +11,16 @@ import NotFoundError from 'src/common/errors/notFoundError';
 import CreatePlanData from './type/createPlanData.interface';
 import UpdatePlanData from './type/updatePlanData.interface';
 import BadRequestError from 'src/common/errors/badRequestError';
+import QuoteService from 'src/quote/quote.service';
+import { QuoteQueryOptions } from 'src/quote/type/quoteQueryOptions.interface';
+import QuoteToClientProperties from 'src/quote/type/quoteToClientProperties.interface';
 
 @Injectable()
 export default class PlanService {
   constructor(
     private readonly planRepository: PlanRepository,
-    private readonly userRepository: UserRepository
+    private readonly userRepository: UserRepository,
+    private readonly quoteService: QuoteService
   ) {}
 
   async getPlans(makerId: string, options: PlanQueryOptions): Promise<{ list: Plan[]; totalCount: number }> {
@@ -45,6 +49,14 @@ export default class PlanService {
     return plan; //TODO. 단일조회시에도 권한이 필요한지 알아봐야됨
   }
 
+  async getQuotesByPlanId(
+    options: QuoteQueryOptions,
+    userId: string
+  ): Promise<{ totalCount: number; list: QuoteToClientProperties[] }> {
+    const { totalCount, list } = await this.quoteService.getQuotesByPlanId(options, userId);
+    return { totalCount, list };
+  }
+
   async postPlan(data: CreatePlanData): Promise<Plan> {
     const dreamer = await this.userRepository.findById(data.dreamerId);
     if (dreamer.get().role !== Role.DREAMER) {
@@ -54,6 +66,7 @@ export default class PlanService {
     const plan = await this.planRepository.create(data);
     return plan;
   }
+
   async updatePlanAssign(id: string, requestUserId: string, data: Partial<UpdatePlanData>): Promise<Plan> {
     const isPlan = await this.planRepository.findById(id);
 

--- a/src/quote/domain/quote.mapper.ts
+++ b/src/quote/domain/quote.mapper.ts
@@ -6,16 +6,15 @@ import UserMapper from 'src/user/domain/user.mapper';
 import ErrorMessage from 'src/common/enums/error.message';
 
 export default class QuoteMapper {
-  constructor(private readonly quote: QuoteMapperProperties) {
-    if (!quote) {
-      throw new NotFoundError(ErrorMessage.QUOTE_NOT_FOUND);
-    }
-  }
+  constructor(private readonly quote: QuoteMapperProperties) {}
 
   toDomain(): Quote {
     let maker: IUser | null = null;
     if (this?.quote?.maker) {
       maker = new UserMapper(this.quote.maker).toDomain();
+    }
+    if (!this.quote) {
+      return null;
     }
 
     return new Quote({

--- a/src/quote/quote.controller.ts
+++ b/src/quote/quote.controller.ts
@@ -1,10 +1,11 @@
-import { Controller, Get, Param } from '@nestjs/common';
+import { Controller, Get, Param, Query } from '@nestjs/common';
 import QuoteService from './quote.service';
 import QuoteRepository from './quote.repository';
 import { Quote } from '@prisma/client';
 import { Public } from 'src/decorator/public.decorator';
 import QuoteToClientProperties from './type/quoteToClientProperties.interface';
 import { User } from 'src/decorator/user.decorator';
+import { QuoteQueryOptionsByDreamerDTO } from './type/quoteQueryOptions.interface';
 
 @Controller('quotes')
 export default class QuoteController {

--- a/src/quote/quote.module.ts
+++ b/src/quote/quote.module.ts
@@ -2,9 +2,11 @@ import { Module } from '@nestjs/common';
 import QuoteController from './quote.controller';
 import QuoteService from './quote.service';
 import QuoteRepository from './quote.repository';
+import PlanModule from 'src/plan/plan.module';
 
 @Module({
   controllers: [QuoteController],
-  providers: [QuoteService, QuoteRepository]
+  providers: [QuoteService, QuoteRepository],
+  exports: [QuoteService]
 })
 export default class QuoteModule {}

--- a/src/quote/quote.repository.ts
+++ b/src/quote/quote.repository.ts
@@ -10,13 +10,12 @@ export default class QuoteRepository {
   constructor(private readonly db: DBClient) {}
 
   async findMany(options: QuoteQueryOptions): Promise<IQuote[]> {
-    const { planId, status, page, pageSize } = options;
+    const { planId, page, pageSize } = options;
 
     const quotes = await this.db.quote.findMany({
       where: {
         planId,
-        isDeletedAt: null,
-        ...(status.length && { plan: { status: { in: status } } })
+        isDeletedAt: null
       },
       take: pageSize,
       skip: (page - 1) * pageSize,
@@ -29,12 +28,11 @@ export default class QuoteRepository {
   }
 
   async totalCount(options: any): Promise<number> {
-    const { planId, status, page, pageSize } = options;
+    const { planId } = options;
     const totalCount = await this.db.quote.count({
       where: {
         planId,
-        isDeletedAt: null,
-        ...(status.length && { plan: { status: { in: status } } })
+        isDeletedAt: null
       }
     });
     return totalCount;

--- a/src/quote/quote.repository.ts
+++ b/src/quote/quote.repository.ts
@@ -2,10 +2,44 @@ import { Injectable } from '@nestjs/common';
 import DBClient from 'prisma/DB.client';
 import IQuote from './domain/quote.interface';
 import QuoteMapper from './domain/quote.mapper';
+import SortOrder from 'src/common/enums/sortOrder';
+import { QuoteQueryOptions } from './type/quoteQueryOptions.interface';
 
 @Injectable()
 export default class QuoteRepository {
   constructor(private readonly db: DBClient) {}
+
+  async findMany(options: QuoteQueryOptions): Promise<IQuote[]> {
+    const { planId, status, page, pageSize } = options;
+
+    const quotes = await this.db.quote.findMany({
+      where: {
+        planId,
+        isDeletedAt: null,
+        ...(status.length && { plan: { status: { in: status } } })
+      },
+      take: pageSize,
+      skip: (page - 1) * pageSize,
+      orderBy: { createdAt: SortOrder.DESC },
+      include: { maker: true }
+    });
+
+    const domainQuotes = quotes.map((quote) => new QuoteMapper(quote).toDomain());
+    return domainQuotes;
+  }
+
+  async totalCount(options: any): Promise<number> {
+    const { planId, status, page, pageSize } = options;
+    const totalCount = await this.db.quote.count({
+      where: {
+        planId,
+        isDeletedAt: null,
+        ...(status.length && { plan: { status: { in: status } } })
+      }
+    });
+    return totalCount;
+  }
+
   async getQuoteById(id: string): Promise<IQuote> {
     const quote = await this.db.quote.findUnique({
       where: { id, isDeletedAt: null },
@@ -15,7 +49,7 @@ export default class QuoteRepository {
       }
     });
 
-    const domainQuote = new QuoteMapper(quote);
-    return domainQuote.toDomain();
+    const domainQuote = new QuoteMapper(quote).toDomain();
+    return domainQuote;
   }
 }

--- a/src/quote/quote.service.ts
+++ b/src/quote/quote.service.ts
@@ -5,13 +5,31 @@ import QuoteToClientProperties from './type/quoteToClientProperties.interface';
 import NotFoundError from 'src/common/errors/notFoundError';
 import ErrorMessage from 'src/common/enums/error.message';
 import ForbiddenError from 'src/common/errors/forbiddenError';
+import { QuoteQueryOptions } from './type/quoteQueryOptions.interface';
 
 @Injectable()
 export default class QuoteService {
   constructor(private readonly quoteRepository: QuoteRepository) {}
 
+  async getQuotesByPlanId(
+    options: QuoteQueryOptions,
+    userId: string
+  ): Promise<{ totalCount: number; list: QuoteToClientProperties[] }> {
+    //TODO. Dreamer 본인인지 권한 체크 필요 -> 데코레이터 예정
+    const [totalCount, list] = await Promise.all([
+      this.quoteRepository.totalCount(options),
+      this.quoteRepository.findMany(options)
+    ]);
+    const toClientList = list.map((quote) => quote.toClient());
+
+    return { totalCount, list: toClientList };
+  }
+
   async getQuoteById(id: string, userId: string): Promise<QuoteToClientProperties> {
     const quote = await this.quoteRepository.getQuoteById(id);
+    if (!quote) {
+      throw new NotFoundError(ErrorMessage.QUOTE_NOT_FOUND);
+    }
     if (userId !== quote.getDreamerId() && userId !== quote.getMakerId()) {
       throw new ForbiddenError(ErrorMessage.QUOTE_FORBIDDEN_ID);
     }

--- a/src/quote/type/quote.mapper.properties.interface.ts
+++ b/src/quote/type/quote.mapper.properties.interface.ts
@@ -9,7 +9,7 @@ export default interface QuoteMapperProperties {
   isDeletedAt?: Date | null;
   price: number;
   content: string;
-  plan: Plan;
+  plan?: Plan;
   planId: string;
   maker?: UserProperties | null;
   makerId?: string | null;

--- a/src/quote/type/quoteQueryOptions.interface.ts
+++ b/src/quote/type/quoteQueryOptions.interface.ts
@@ -1,0 +1,45 @@
+import { Transform, Type } from 'class-transformer';
+import { ArrayNotEmpty, IsArray, IsEnum, IsOptional, IsString, IsUUID } from 'class-validator';
+import ErrorMessage from 'src/common/enums/error.message';
+import BadRequestError from 'src/common/errors/badRequestError';
+import { Status, StatusEnum } from 'src/common/types/status.type';
+
+export interface QuoteQueryOptions {
+  planId?: string;
+  status: StatusEnum[];
+  page: number;
+  pageSize: number;
+}
+/**
+ * NOTE.
+ * 드리머 입장 planId, page, pageSize, status(대기, 완료, 만료)
+ * 메이커 입장 유저토큰, page, pageSize,
+ */
+
+export class QuoteQueryOptionsByDreamerDTO {
+  @Transform(({ value }) => (Array.isArray(value) ? value : [value]))
+  @IsArray() //NOTE. 피그마의 대기중은 PENDING+CONFIRMED
+  @ArrayNotEmpty()
+  @IsEnum(StatusEnum, { each: true })
+  status: StatusEnum[];
+
+  @IsOptional()
+  @Type(() => Number)
+  page: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  pageSize: number = 2;
+}
+// export class QuoteQueryOptionByMakerDTO {
+//   /**
+//    * NOTE. 보낸견적 조회, 취소된 플랜
+//    */
+//   @IsOptional()
+//   @Type(() => Number)
+//   page: number = 1;
+
+//   @IsOptional()
+//   @Type(() => Number)
+//   pageSize: number = 2;
+// }

--- a/src/quote/type/quoteQueryOptions.interface.ts
+++ b/src/quote/type/quoteQueryOptions.interface.ts
@@ -6,7 +6,6 @@ import { Status, StatusEnum } from 'src/common/types/status.type';
 
 export interface QuoteQueryOptions {
   planId?: string;
-  status: StatusEnum[];
   page: number;
   pageSize: number;
 }
@@ -17,12 +16,6 @@ export interface QuoteQueryOptions {
  */
 
 export class QuoteQueryOptionsByDreamerDTO {
-  @Transform(({ value }) => (Array.isArray(value) ? value : [value]))
-  @IsArray() //NOTE. 피그마의 대기중은 PENDING+CONFIRMED
-  @ArrayNotEmpty()
-  @IsEnum(StatusEnum, { each: true })
-  status: StatusEnum[];
-
   @IsOptional()
   @Type(() => Number)
   page: number = 1;


### PR DESCRIPTION
## 작업한 이슈 번호

- close #32 

## 작업 사항 설명

- Dreamer의 본인 플랜에 대한 견적 조회

## 작업 사항

- [x] Dreamer의 본인 플랜에 대한 견적 조회 api 구현

## 기타
# Dreamer의 Quote 리스트 조회

```jsx
GET plans/:planId/quotes
옵셔널:  page, pageSize

response
{
  "totalCount": 3,
  "list": [
    {
      "id": "e00fce11-75bb-400a-99da-24ef6ca0e2c3",
      "createdAt": "2023-10-03T09:15:00.000Z",
      "updatedAt": "2023-10-03T09:45:00.000Z",
      "price": 2000,
      "content": "7일 간의 일본 그룹 투어, 단체 할인 적용.",
      "maker": {
        "id": "b3c4d5e6-f789-0123-4567-890abcdef123",
        "role": "MAKER",
        "nickName": "개나리",
        "coconut": 1000
      },
      "isConfirmed": true,
      "isAssigned": true
    },
    {
      "id": "be7f1e1c-5192-4fa7-9e5e-8e228a8d8038",
      "createdAt": "2023-10-02T12:00:00.000Z",
      "updatedAt": "2023-10-02T12:30:00.000Z",
      "price": 1500,
      "content": "5일 간의 고급 투어 패키지, 프리미엄 호텔과 독점적인 경험 포함.",
      "maker": null,
      "isConfirmed": false,
      "isAssigned": true
    }
  ]
}
```

### 필수요소

- planId : Param

### 옵셔널 요소

- page: 기본값 1
- pageSize: 기본값 2

### API 정의

- Dreamer가 본인의 Plan에 대한 견적서를 확인하는 용도
- 본인 이외에는 조회 불가능(데코레이터 처리 예정)