### PR TITLE
Feat: #41 isConfirmed 옵셔널 필드 추가

### DIFF
--- a/httpTest/quote.http
+++ b/httpTest/quote.http
@@ -8,7 +8,7 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJhMmIzY
 GET http://localhost:4000/quotes/be7f1e1c-5192-4fa7-9e5e-8e228a8d8038
 #유저가 삭제됐을 때 테스트
 ###
-GET http://localhost:4000/plans/8fc40908-9269-4db3-ad7d-fb6e69b0ba0d/quotes?status=PENDING
+GET http://localhost:4000/plans/8fc40908-9269-4db3-ad7d-fb6e69b0ba0d/quotes?isConfirmed=true
 Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJhMWIyYzNkNC1lNWY2LTc4OTAtYWJjZC0xMjM0NTY3ODkwZWYiLCJpYXQiOjE3MzY0ODgwOTgsImV4cCI6MTczNzA5Mjg5OH0.3FF1yKyL9m703ZeWsBtu3HcmmXywsqweOn7WabnS8bY
 #Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJiMmMzZDRlNS1mNjc4LTkwYWItY2RlZi0yMzQ1Njc4OTAxYWIiLCJpYXQiOjE3MzY0ODgyMDksImV4cCI6MTczNzA5MzAwOX0.wvas5nApZhmBgbW71mh5gOs9RFHvrfEEFuf6cghQXrw
 #GetByDreamer 테스트

--- a/src/quote/quote.service.ts
+++ b/src/quote/quote.service.ts
@@ -18,7 +18,7 @@ export default class QuoteService {
     userId: string
   ): Promise<{ totalCount: number; list: QuoteToClientProperties[] }> {
     //TODO. Dreamer 본인인지 권한 체크 필요 -> 데코레이터 예정
-    const { planId, page, pageSize } = options;
+    const { planId, isConfirmed, page, pageSize } = options;
     const whereConditions = this.buildWhereConditions(options);
     options.whereConditions = whereConditions;
 
@@ -58,7 +58,7 @@ export default class QuoteService {
   }
 
   private buildWhereConditions(options: QuoteQueryOptions): QuoteWhereInput {
-    const { planId, isSent, userId } = options || {};
+    const { planId, isConfirmed, isSent, userId } = options || {};
     let whereConditions: QuoteWhereInput = {
       isDeletedAt: null
     };
@@ -69,6 +69,10 @@ export default class QuoteService {
 
     if (planId) {
       whereConditions.planId = planId; // planId 조건 추가
+    }
+
+    if (isConfirmed === true) {
+      whereConditions.isConfirmed = true;
     }
 
     if (isSent === true) {

--- a/src/quote/type/quote.dto.ts
+++ b/src/quote/type/quote.dto.ts
@@ -18,6 +18,18 @@ export class DreamerQuoteQueryOptionsDTO {
   @IsOptional()
   @Type(() => Number)
   pageSize: number = 2;
+
+  @IsOptional()
+  @Transform(({ value }) => {
+    if (value === 'true') {
+      return true;
+    } else if (value === 'false') {
+      return false;
+    } else {
+      throw new BadRequestError(ErrorMessage.BOOLEAN_BAD_REQUEST_isSent);
+    }
+  })
+  isConfirmed: boolean = false;
 }
 export class MakerQuoteQueryOptions {
   /**
@@ -41,7 +53,6 @@ export class MakerQuoteQueryOptions {
       throw new BadRequestError(ErrorMessage.BOOLEAN_BAD_REQUEST_isSent);
     }
   })
-  @IsDefined()
   isSent: boolean;
 }
 /**

--- a/src/quote/type/quote.type.ts
+++ b/src/quote/type/quote.type.ts
@@ -12,7 +12,7 @@ export interface QuoteQueryOptions {
   page: number;
   pageSize: number;
   planId?: string;
-  // status?: StatusEnum[];
+  isConfirmed?: boolean;
   isSent?: boolean;
   userId?: string;
   whereConditions?: QuoteWhereInput;


### PR DESCRIPTION
## 작업한 이슈 번호

- close #41 

## 작업 사항 설명

드리머의 견적 목록 조회에서 isConfirmed 쿼리를 추가
확정된 견적만 리스폰스로 돌려주게함
디폴트는 false

## 작업 사항

- [x] 드리머의 견적 목록 조회에서 isConfirmed 쿼리를 추가

## 기타

# Dreamer의 Quote 리스트 조회

```jsx
GET plans/:planId/quotes
예시 plans/:planId/quotes?isConfirmed=true
예시 plans/:planId/quotes?page=2&pageSize=2

response
{
  "totalCount": 3,
  "list": [
    {
      "id": "e00fce11-75bb-400a-99da-24ef6ca0e2c3",
      "createdAt": "2023-10-03T09:15:00.000Z",
      "updatedAt": "2023-10-03T09:45:00.000Z",
      "price": 2000,
      "content": "7일 간의 일본 그룹 투어, 단체 할인 적용.",
      "maker": {
        "id": "b3c4d5e6-f789-0123-4567-890abcdef123",
        "role": "MAKER",
        "nickName": "개나리",
        "coconut": 1000
      },
      "isConfirmed": true,
      "isAssigned": true
    },
    {
      "id": "be7f1e1c-5192-4fa7-9e5e-8e228a8d8038",
      "createdAt": "2023-10-02T12:00:00.000Z",
      "updatedAt": "2023-10-02T12:30:00.000Z",
      "price": 1500,
      "content": "5일 간의 고급 투어 패키지, 프리미엄 호텔과 독점적인 경험 포함.",
      "maker": null,
      "isConfirmed": false,
      "isAssigned": true
    }
  ]
}
```

### 필수요소

- planId : params로 입력

### 옵셔널 요소

- page: 기본값 1
- pageSize: 기본값 2
- isConfirmed: 기본값 false
    - true로 값이 들어오면 확정된 견적서만 리스폰스로 돌려준다.

### API 정의

- Dreamer가 본인의 Plan에 대한 견적서를 확인하는 용도
- 본인 이외에는 조회 불가능(데코레이터 처리 대기중)
- 
