### PR TITLE
지정 견적 요청시 maker에게 알림 발송하기

### DIFF
--- a/mongoose/notification.schema.ts
+++ b/mongoose/notification.schema.ts
@@ -1,13 +1,12 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { HydratedDocument, Types } from 'mongoose';
-import { v4 as uuidv4 } from 'uuid';
 
 @Schema({ timestamps: true })
 export class Notification {
   @Prop({ default: null })
   isDeletedAt: Date | null;
 
-  @Prop({ type: String, default: uuidv4 })
+  @Prop({ type: String })
   userId: string | null;
 
   @Prop({ isRequired: true })

--- a/src/notification/notification.controller.ts
+++ b/src/notification/notification.controller.ts
@@ -22,7 +22,7 @@ export default class NotificationController {
   // 로그인 시 알림 SSE stream 연결 요청
   @Public()
   @Sse('stream')
-  stream(@User() userId: string): Observable<any> {
+  stream(@User() userId: string): Observable<{ data: string }> {
     console.log(`SSE connection for userId: ${userId}`);
     return this.service.stream(userId).pipe(
       map((content: string) => {

--- a/src/notification/notification.controller.ts
+++ b/src/notification/notification.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, Patch, Post, Sse } from '@nestjs/common';
+import { Controller, Get, Param, Patch, Sse } from '@nestjs/common';
 import NotificationService from './notification.service';
 import { User } from 'src/decorator/user.decorator';
 import { map, Observable } from 'rxjs';
@@ -21,8 +21,8 @@ export default class NotificationController {
 
   // 로그인 시 알림 SSE stream 연결 요청
   @Public()
-  @Sse('stream/:userId')
-  stream(@Param('userId') userId: string): Observable<any> {
+  @Sse('stream')
+  stream(@User() userId: string): Observable<any> {
     console.log(`SSE connection for userId: ${userId}`);
     return this.service.stream(userId).pipe(
       map((content: string) => {

--- a/src/notification/notification.event.ts
+++ b/src/notification/notification.event.ts
@@ -1,0 +1,6 @@
+export default class NotificationEvent {
+  constructor(
+    public readonly userId: string,
+    public readonly content: string
+  ) {}
+}

--- a/src/notification/notification.listener.ts
+++ b/src/notification/notification.listener.ts
@@ -1,0 +1,13 @@
+import { OnEvent } from '@nestjs/event-emitter';
+import NotificationService from './notification.service';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class NotificationListener {
+  constructor(private readonly notification: NotificationService) {}
+
+  @OnEvent('notification')
+  async handleNotificationEvent(userId: string, content: string): Promise<void> {
+    await this.notification.create(userId, content);
+  }
+}

--- a/src/notification/notification.listener.ts
+++ b/src/notification/notification.listener.ts
@@ -7,7 +7,7 @@ export class NotificationListener {
   constructor(private readonly notification: NotificationService) {}
 
   @OnEvent('notification')
-  async handleNotificationEvent(userId: string, content: string): Promise<void> {
-    await this.notification.create(userId, content);
+  async handleNotificationEvent(event: { userId: string; content: string }): Promise<void> {
+    await this.notification.create(event.userId, event.content);
   }
 }

--- a/src/notification/notification.module.ts
+++ b/src/notification/notification.module.ts
@@ -4,11 +4,12 @@ import NotificationRepository from './notification.repository';
 import NotificationService from './notification.service';
 import { MongooseModule } from '@nestjs/mongoose';
 import NotificationSchema, { Notification } from 'mongoose/notification.schema';
+import { NotificationListener } from './notification.listener';
 
 @Module({
   imports: [MongooseModule.forFeature([{ name: Notification.name, schema: NotificationSchema }])],
   controllers: [NotificationController],
-  providers: [NotificationRepository, NotificationService],
+  providers: [NotificationRepository, NotificationService, NotificationListener],
   exports: []
 })
 export default class NotificationModule {}

--- a/src/notification/notification.service.ts
+++ b/src/notification/notification.service.ts
@@ -40,7 +40,7 @@ export default class NotificationService {
     return readNotification.get();
   }
 
-  stream(userId: string): Observable<any> {
+  stream(userId: string): Observable<string> {
     return new Observable((subscriber) => {
       const handler = (data: { content: string }) => {
         subscriber.next(data.content);

--- a/src/notification/notification.service.ts
+++ b/src/notification/notification.service.ts
@@ -22,7 +22,6 @@ export default class NotificationService {
   async create(userId: string, content: string): Promise<NotificationProperties> {
     const notification = await this.repository.create(userId, content);
 
-    // FIXME: 실시간 알림 발송 시 알림 종류에 따라 달라지는 user, content 전달 방식에 대한 수정 필요
     this.eventEmitter.emit(`notification:${userId}`, {
       content: notification.get().content
     });


### PR DESCRIPTION
## 작업한 이슈 번호

- close #33 

## 작업 사항 설명

알림 이벤트 설정 및 지정 견적 요청시 알림 발송 추가

## 작업 사항

- [x] 알림 이벤트 설정 (전역에 eventEmitter로 추가 가능)
- [x] Plan API의 지정 견적 요청시 maker에서 알림 발송 추가

## 기타

- 지정 견적 API 관련 수정사항 및 궁금한 점(?) 주석으로 남겨놓았습니다!
- 추후 eventEmitter로 같은 형식으로 알림 데이터 저장 및 실시간 발송할 수 있도록 테스트 완료했습니다!
