### PR TITLE
유저 정보 수정 시 비밀번호 확인 기능 추가

### DIFF
--- a/httpTest/user.http
+++ b/httpTest/user.http
@@ -21,13 +21,13 @@ POST http://localhost:3100/user/login
 Content-Type: application/json
 
 {
-	"email": "bfbda@naver.com",
-	"password": "123456789"
+	"email": "asdfdfasd@naver.com",
+	"password": "12345678"
 }
 
 ###
 PATCH http://localhost:3100/user/update
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiIwZWY3MmFjNy1hZmViLTQyNzItYjc2Yi1iNjRkOTNhZTc4NzkiLCJpYXQiOjE3MzYyMjc3NzgsImV4cCI6MTczNjMxNDE3OH0.15V3Va4QzmCeUH2ua3Zt5wM7NVp5v9cfwAlHnTtKpME
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiI3ZDI5ZWRmNi1iMWQxLTQxNWEtOWI3OS1jNWU2NGRmY2E3YmEiLCJyb2xlIjoiRFJFQU1FUiIsImlhdCI6MTczNjc1NzM2NCwiZXhwIjoxNzM2ODQzNzY0fQ.gkcFRuf3Il8_fvyJTHJYbdo1jwB4IoeANWWalIO6Jnk
 Content-Type: application/json
 
 {

--- a/src/common/enums/error.message.ts
+++ b/src/common/enums/error.message.ts
@@ -13,6 +13,7 @@ const enum ErrorMessage {
 
   TOKEN_UNAUTHORIZED_NOTFOUND = '토큰이 없습니다. 로그인이 필요합니다',
   TOKEN_UNAUTHORIZED_VALIDATION = '유효하지 않은 토큰입니다',
+  REFRESH_TOKEN_NOT_FOUND = '리프레시 토큰이 없습니다',
 
   FOLLOW_EXIST = '이미 팔로우한 유저입니다',
   FOLLOW_NOT_FOUND = '팔로우하지 않은 유저입니다',

--- a/src/common/enums/error.message.ts
+++ b/src/common/enums/error.message.ts
@@ -4,7 +4,6 @@ const enum ErrorMessage {
   USER_NICKNAME_EXIST = '이미 존재하는 닉네임입니다.',
   USER_UNAUTHORIZED_ID = '존재하지 않는 email 입니다.',
   USER_UNAUTHORIZED_PW = '비밀번호가 일치하지 않습니다.',
-  USER_BAD_REQUEST_PW = '새 비밀번호와 비밀번호 확인이 일치하지 않습니다',
   USER_UNAUTHORIZED_TOKEN = '토큰의 유효기간이 만료되었습니다. 로그인이 필요합니다',
   USER_FORBIDDEN_NOT_OWNER = 'Plan을 등록한 본인만 수정, 삭제할 수 있습니다. 권한을 확인해주세요.',
   USER_FORBIDDEN_NOT_MAKER = 'Maker 역할을 가진 사용자만 이 리소스에 접근할 수 있습니다. 권한을 확인해 주세요.',

--- a/src/common/enums/error.message.ts
+++ b/src/common/enums/error.message.ts
@@ -4,6 +4,7 @@ const enum ErrorMessage {
   USER_NICKNAME_EXIST = '이미 존재하는 닉네임입니다.',
   USER_UNAUTHORIZED_ID = '존재하지 않는 email 입니다.',
   USER_UNAUTHORIZED_PW = '비밀번호가 일치하지 않습니다.',
+  USER_BAD_REQUEST_PW = '새 비밀번호와 비밀번호 확인이 일치하지 않습니다',
   USER_UNAUTHORIZED_TOKEN = '토큰의 유효기간이 만료되었습니다. 로그인이 필요합니다',
   USER_FORBIDDEN_NOT_OWNER = 'Plan을 등록한 본인만 수정, 삭제할 수 있습니다. 권한을 확인해주세요.',
   USER_FORBIDDEN_NOT_MAKER = 'Maker 역할을 가진 사용자만 이 리소스에 접근할 수 있습니다. 권한을 확인해 주세요.',

--- a/src/decorator/cookie.decorator.ts
+++ b/src/decorator/cookie.decorator.ts
@@ -1,6 +1,7 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 
 export const Cookies = createParamDecorator((data: string, ctx: ExecutionContext) => {
-  const request = ctx.switchToHttp().getRequest();
-  return data ? request.cookies?.[data] : request.cookies;
+  const cookies = ctx.switchToHttp().getRequest().cookies || {};
+
+  return cookies?.[data] || cookies;
 });

--- a/src/decorator/cookie.decorator.ts
+++ b/src/decorator/cookie.decorator.ts
@@ -1,7 +1,7 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 
 export const Cookies = createParamDecorator((data: string, ctx: ExecutionContext) => {
-  const cookies = ctx.switchToHttp().getRequest().cookies || {};
+  const cookies = ctx.switchToHttp().getRequest().cookies;
 
-  return cookies?.[data] || cookies;
+  return data ? cookies?.[data] : undefined;
 });

--- a/src/user/domain/user.domain.ts
+++ b/src/user/domain/user.domain.ts
@@ -1,9 +1,10 @@
 import { Role } from 'src/common/types/role.type';
-import { FilteredUserProperties, UserProperties } from '../type/user.types';
+import { FilteredUserProperties, UpdatePasswordProperties, UserProperties } from '../type/user.types';
 import { ComparePassword, HashingPassword } from '../../common/utility/hashingPassword';
 import { IUser } from './user.interface';
 import BadRequestError from 'src/common/errors/badRequestError';
 import ErrorMessage from 'src/common/enums/error.message';
+import UnauthorizedError from 'src/common/errors/unauthorizedError';
 
 export default class User implements IUser {
   private readonly id?: string;
@@ -37,22 +38,37 @@ export default class User implements IUser {
     return ComparePassword(password, this.password);
   }
 
-  update(data: Partial<UserProperties>): Partial<UserProperties> {
+  async update(data: Partial<UserProperties> & UpdatePasswordProperties): Promise<FilteredUserProperties> {
+    if (data.password) {
+      await this.updatePassword({
+        password: data.password,
+        newPassword: data.newPassword,
+        confirmNewPassword: data.confirmNewPassword
+      });
+    }
+
     if (data.coconut < 0) {
       throw new BadRequestError(ErrorMessage.USER_COCONUT_INVALID);
     }
 
     this.nickName = data.nickName || this.nickName;
-    this.password = data.email || this.password;
     this.phoneNumber = data.phoneNumber || this.phoneNumber;
     this.coconut = data.coconut || this.coconut;
 
-    return {
-      nickName: this.nickName,
-      password: this.password,
-      phoneNumber: this.phoneNumber,
-      coconut: this.coconut
-    };
+    return this.toClient();
+  }
+
+  async updatePassword(data: UpdatePasswordProperties): Promise<void> {
+    const isCorrectPassword = await this.validatePassword(data.password);
+    if (!isCorrectPassword) {
+      throw new UnauthorizedError(ErrorMessage.USER_UNAUTHORIZED_PW);
+    }
+
+    if (data.newPassword !== data.confirmNewPassword) {
+      throw new BadRequestError(ErrorMessage.USER_BAD_REQUEST_PW);
+    }
+
+    this.password = await HashingPassword(data.newPassword);
   }
 
   get(): UserProperties {

--- a/src/user/domain/user.domain.ts
+++ b/src/user/domain/user.domain.ts
@@ -1,5 +1,5 @@
 import { Role } from 'src/common/types/role.type';
-import { FilteredUserProperties, UpdatePasswordProperties, UserProperties } from '../type/user.types';
+import { FilteredUserProperties, PasswordProperties, UserProperties } from '../type/user.types';
 import { ComparePassword, HashingPassword } from '../../common/utility/hashingPassword';
 import { IUser } from './user.interface';
 import BadRequestError from 'src/common/errors/badRequestError';
@@ -38,12 +38,11 @@ export default class User implements IUser {
     return ComparePassword(password, this.password);
   }
 
-  async update(data: Partial<UserProperties> & UpdatePasswordProperties): Promise<FilteredUserProperties> {
+  async update(data: Partial<UserProperties> & PasswordProperties): Promise<FilteredUserProperties> {
     if (data.password) {
       await this.updatePassword({
         password: data.password,
-        newPassword: data.newPassword,
-        confirmNewPassword: data.confirmNewPassword
+        newPassword: data.newPassword
       });
     }
 
@@ -58,14 +57,10 @@ export default class User implements IUser {
     return this.toClient();
   }
 
-  async updatePassword(data: UpdatePasswordProperties): Promise<void> {
+  async updatePassword(data: PasswordProperties): Promise<void> {
     const isCorrectPassword = await this.validatePassword(data.password);
     if (!isCorrectPassword) {
       throw new UnauthorizedError(ErrorMessage.USER_UNAUTHORIZED_PW);
-    }
-
-    if (data.newPassword !== data.confirmNewPassword) {
-      throw new BadRequestError(ErrorMessage.USER_BAD_REQUEST_PW);
     }
 
     this.password = await HashingPassword(data.newPassword);

--- a/src/user/domain/user.interface.ts
+++ b/src/user/domain/user.interface.ts
@@ -1,9 +1,9 @@
-import { FilteredUserProperties, UpdatePasswordProperties, UserProperties } from '../type/user.types';
+import { FilteredUserProperties, PasswordProperties, UserProperties } from '../type/user.types';
 
 export interface IUser {
   validatePassword(password: string): Promise<boolean>;
-  update(data: Partial<UserProperties> & UpdatePasswordProperties): Promise<FilteredUserProperties>;
-  updatePassword(data: UpdatePasswordProperties): Promise<void>;
+  update(data: Partial<UserProperties> & PasswordProperties): Promise<FilteredUserProperties>;
+  updatePassword(data: PasswordProperties): Promise<void>;
   get(): UserProperties;
   toClient(): FilteredUserProperties;
   toClientAll(): Omit<UserProperties, 'password'>;

--- a/src/user/domain/user.interface.ts
+++ b/src/user/domain/user.interface.ts
@@ -1,8 +1,9 @@
-import { FilteredUserProperties, UserProperties } from '../type/user.types';
+import { FilteredUserProperties, UpdatePasswordProperties, UserProperties } from '../type/user.types';
 
 export interface IUser {
   validatePassword(password: string): Promise<boolean>;
-  update(data: Partial<UserProperties>): Partial<UserProperties>;
+  update(data: Partial<UserProperties> & UpdatePasswordProperties): Promise<FilteredUserProperties>;
+  updatePassword(data: UpdatePasswordProperties): Promise<void>;
   get(): UserProperties;
   toClient(): FilteredUserProperties;
   toClientAll(): Omit<UserProperties, 'password'>;

--- a/src/user/type/updateUser.dto.ts
+++ b/src/user/type/updateUser.dto.ts
@@ -1,4 +1,30 @@
-import { PartialType } from '@nestjs/swagger';
-import { SignupUserDTO } from './signup.dto';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsOptional, IsString } from 'class-validator';
+import { RoleEnum } from 'src/common/types/role.type';
 
-export default class UpdateUserDTO extends PartialType(SignupUserDTO) {}
+export default class UpdateUserDTO {
+  @ApiProperty({ example: 'DEFAULT_1', enum: RoleEnum })
+  @IsEnum(RoleEnum)
+  @IsOptional()
+  role: RoleEnum;
+
+  @IsString()
+  @IsOptional()
+  nickName: string;
+
+  @IsString()
+  @IsOptional()
+  password: string;
+
+  @IsString()
+  @IsOptional()
+  newPassword: string;
+
+  @IsString()
+  @IsOptional()
+  confirmNewPassword: string;
+
+  @IsString()
+  @IsOptional()
+  phoneNumber: string;
+}

--- a/src/user/type/user.types.ts
+++ b/src/user/type/user.types.ts
@@ -18,3 +18,9 @@ export interface FilteredUserProperties {
   nickName: string;
   coconut: number;
 }
+
+export interface UpdatePasswordProperties {
+  password: string;
+  newPassword: string;
+  confirmNewPassword: string;
+}

--- a/src/user/type/user.types.ts
+++ b/src/user/type/user.types.ts
@@ -19,8 +19,7 @@ export interface FilteredUserProperties {
   coconut: number;
 }
 
-export interface UpdatePasswordProperties {
+export interface PasswordProperties {
   password: string;
   newPassword: string;
-  confirmNewPassword: string;
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -91,7 +91,7 @@ export default class UserController {
   @ApiBody({ type: UpdateUserDTO })
   @ApiOkResponse({ type: FilteredUserResponseDTO })
   @ApiUnauthorizedResponse({ description: 'Access Token이 없거나 만료되었습니다' })
-  async updateUser(@Body() data: Partial<UserProperties>, @User() userId: string): Promise<FilteredUserProperties> {
+  async updateUser(@Body() data: UpdateUserDTO, @User() userId: string): Promise<FilteredUserProperties> {
     return await this.service.updateUser(userId, data);
   }
 

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -27,6 +27,8 @@ import UpdateProfileDTO from './type/updateProfile.dto';
 import { DreamerProfileProperties, MakerProfileProperties } from './type/profile.types';
 import { FilteredUserProperties, UserProperties } from './type/user.types';
 import UpdateUserDTO from './type/updateUser.dto';
+import UnauthorizedError from 'src/common/errors/unauthorizedError';
+import ErrorMessage from 'src/common/enums/error.message';
 
 @Controller('user')
 export default class UserController {
@@ -50,8 +52,8 @@ export default class UserController {
   @ApiBadRequestResponse({ description: '이메일 또는 비밀번호가 유저 정보와 일치하지 않습니다' })
   async login(@Body() data: LoginDTO, @Res() res: Response): Promise<void> {
     const user = await this.service.login(data.email, data.password);
-    const accessToken = this.service.createToken(user.id);
-    const refreshToken = this.service.createToken(user.id, 'refresh');
+    const tokenPayload = { userId: user.id, role: user.role };
+    const { accessToken, refreshToken } = this.service.createTokens(tokenPayload);
 
     res.cookie('refreshToken', refreshToken, {
       path: '/user/token/refresh',
@@ -120,9 +122,11 @@ export default class UserController {
   @ApiCreatedResponse({ description: '{ accessToken }' })
   @ApiUnauthorizedResponse({ description: 'Refresh Token이 없거나 만료되었습니다' })
   async getNewToken(@Cookies('refreshToken') refreshToken: string, @Res() res: Response): Promise<void> {
-    const userId = this.service.getPayload(refreshToken);
-    const accessToken = this.service.createToken(userId);
-    const newRefreshToken = this.service.createToken(userId, 'refresh');
+    if (!refreshToken) {
+      throw new UnauthorizedError(ErrorMessage.REFRESH_TOKEN_NOT_FOUND);
+    }
+
+    const { accessToken, refreshToken: newRefreshToken } = this.service.createNewToken(refreshToken);
 
     res.cookie('refreshToken', newRefreshToken, {
       path: '/user/token/refresh',

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -84,8 +84,8 @@ export default class UserService {
   }
 
   createNewToken(oldToken: string) {
-    const { payload } = this.jwt.verify(oldToken);
-    return this.createTokens(payload);
+    const { userId, role } = this.jwt.verify(oldToken);
+    return this.createTokens({ userId, role });
   }
 
   async updateUser(

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -76,19 +76,16 @@ export default class UserService {
     return profile.get();
   }
 
-  createToken(userId: string, type?: string): string {
-    // FIXME: 토큰 생성 부분 수정 예정
-    const payload = { userId };
-    const options = {
-      expiresIn: type === process.env.TOKEN_NAME ? process.env.ACCESS_TOKEN_EXPIRY : process.env.REFRESH_TOKEN_EXPIRY
-    };
+  createTokens(payload: { userId: string; role: string }) {
+    const accessToken = this.jwt.sign(payload, { expiresIn: process.env.ACCESS_TOKEN_EXPIRY });
+    const refreshToken = this.jwt.sign(payload, { expiresIn: process.env.REFRESH_TOKEN_EXPIRY });
 
-    return this.jwt.sign(payload, options);
+    return { accessToken, refreshToken };
   }
 
-  getPayload(refreshToken: string): string {
-    const { userId } = this.jwt.verify(refreshToken);
-    return userId;
+  createNewToken(oldToken: string) {
+    const { payload } = this.jwt.verify(oldToken);
+    return this.createTokens(payload);
   }
 
   async updateUser(

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -5,7 +5,7 @@ import ErrorMessage from 'src/common/enums/error.message';
 import User from './domain/user.domain';
 import { JwtService } from '@nestjs/jwt';
 import { DreamerProfile, MakerProfile } from './domain/profile.domain';
-import { FilteredUserProperties, UserProperties } from './type/user.types';
+import { FilteredUserProperties, UpdatePasswordProperties, UserProperties } from './type/user.types';
 import { DreamerProfileProperties, MakerProfileProperties } from './type/profile.types';
 
 @Injectable()
@@ -91,14 +91,18 @@ export default class UserService {
     return userId;
   }
 
-  async updateUser(userId: string, data: Partial<UserProperties>): Promise<FilteredUserProperties> {
+  async updateUser(
+    userId: string,
+    data: Partial<UserProperties> & UpdatePasswordProperties
+  ): Promise<FilteredUserProperties> {
     const user = await this.repository.findById(userId);
     if (!user) {
       throw new BadRequestError(ErrorMessage.USER_NOT_FOUND);
     }
 
-    const newUser = await this.repository.update(userId, user.update(data));
-    return newUser.get();
+    await user.update(data);
+    const newUser = await this.repository.update(userId, user.get());
+    return newUser.toClient();
   }
 
   async updateDreamerProfile(

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -5,7 +5,7 @@ import ErrorMessage from 'src/common/enums/error.message';
 import User from './domain/user.domain';
 import { JwtService } from '@nestjs/jwt';
 import { DreamerProfile, MakerProfile } from './domain/profile.domain';
-import { FilteredUserProperties, UpdatePasswordProperties, UserProperties } from './type/user.types';
+import { FilteredUserProperties, PasswordProperties, UserProperties } from './type/user.types';
 import { DreamerProfileProperties, MakerProfileProperties } from './type/profile.types';
 
 @Injectable()
@@ -90,7 +90,7 @@ export default class UserService {
 
   async updateUser(
     userId: string,
-    data: Partial<UserProperties> & UpdatePasswordProperties
+    data: Partial<UserProperties> & PasswordProperties
   ): Promise<FilteredUserProperties> {
     const user = await this.repository.findById(userId);
     if (!user) {


### PR DESCRIPTION
## 작업한 이슈 번호

- close #48 

## 작업 사항 설명

유저 정보 수정 시 기존 비밀번호와 대조 및 새 비밀번호와 확인용 비밀번호 일치 여부 확인 기능 추가

## 작업 사항

- [x] 기존 비밀번호와 대조하여 일치 여부 확인
- [x] 새 비밀번호와 확인용 비밀번호 일치 여부 확인

## 기타

- User domain 수정 및 반환 타입 수정했습니다.
- 각각 password, newPassword, confirmNewPassword로 추가했습니다.
- 추가 커밋 : 쿠키 데코레이터 수정 및 토큰 재발급 코드 리팩토링
