### PR TITLE
회원가입시 이메일, 닉네임 중복 확인 API 구현

### DIFF
--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -151,6 +151,6 @@ export default class UserController {
   @HttpCode(HttpStatus.OK)
   @Post('check/nickname')
   async checkNickName(@Body() body: { nickName: string }): Promise<boolean> {
-    return await this.service.checkEmail(body.nickName);
+    return await this.service.checkNickName(body.nickName);
   }
 }

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Patch, Post, Res } from '@nestjs/common';
+import { Body, Controller, Get, HttpCode, HttpStatus, Patch, Post, Res } from '@nestjs/common';
 import UserService from './user.service';
 import { Cookies } from 'src/common/decorators/cookie.decorator';
 import { Public } from 'src/common/decorators/public.decorator';
@@ -138,5 +138,19 @@ export default class UserController {
     });
 
     res.json({ accessToken });
+  }
+
+  @Public()
+  @HttpCode(HttpStatus.OK)
+  @Post('check/email')
+  async checkEmail(@Body() body: { email: string }): Promise<boolean> {
+    return await this.service.checkEmail(body.email);
+  }
+
+  @Public()
+  @HttpCode(HttpStatus.OK)
+  @Post('check/nickname')
+  async checkNickName(@Body() body: { nickName: string }): Promise<boolean> {
+    return await this.service.checkEmail(body.nickName);
   }
 }

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -125,14 +125,14 @@ export default class UserService {
   }
 
   async checkEmail(email: string) {
-    const findByEmail = await this.repository.findByEmail(email);
+    const user = await this.repository.findByEmail(email);
 
-    return !findByEmail;
+    return !user;
   }
 
   async checkNickName(nickName: string) {
-    const findByNickName = await this.repository.findByNickName(nickName);
+    const user = await this.repository.findByNickName(nickName);
 
-    return !findByNickName;
+    return !user;
   }
 }

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -123,4 +123,16 @@ export default class UserService {
     const newProfile = await this.repository.updateMakerProfile(userId, profile.update(data));
     return newProfile.get();
   }
+
+  async checkEmail(email: string) {
+    const findByEmail = await this.repository.findByEmail(email);
+
+    return !findByEmail;
+  }
+
+  async checkNickName(nickName: string) {
+    const findByNickName = await this.repository.findByNickName(nickName);
+
+    return !findByNickName;
+  }
 }


### PR DESCRIPTION
## 작업한 이슈 번호

- close #61 

## 작업 사항 설명

기존 데이터베이스에서 이메일, 닉네임 중복 확인하는 API를 각각 구현합니다

## 작업 사항

- [x] 이메일 중복 API
- [x] 닉네임 중복 API

## 기타

- 존재하는 이메일/닉네임일 경우 false, 사용가능한 경우 true를 반환합니다.
