### PR TITLE
결제 생성 및 결제 상태 조회 API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@nestjs/passport": "^10.0.3",
         "@nestjs/platform-express": "^10.0.0",
         "@nestjs/swagger": "^8.1.0",
+        "@portone/server-sdk": "^0.9.0",
         "@prisma/client": "^6.1.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
@@ -1946,6 +1947,12 @@
       "funding": {
         "url": "https://opencollective.com/unts"
       }
+    },
+    "node_modules/@portone/server-sdk": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@portone/server-sdk/-/server-sdk-0.9.0.tgz",
+      "integrity": "sha512-0yNreS53JocRbVNj2BdvxnsD60n8EpHhXty71H/zXd0IOXkCRs5ZFlRV2oNj1DopUgrZt36oqh5Jk+5dlreU1A==",
+      "license": "(Apache-2.0 OR MIT)"
     },
     "node_modules/@prisma/client": {
       "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@nestjs/passport": "^10.0.3",
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/swagger": "^8.1.0",
+    "@portone/server-sdk": "^0.9.0",
     "@prisma/client": "^6.1.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,6 +11,7 @@ import NotificationModule from './modules/notification/notification.module';
 import FollowModule from './modules/follow/follow.module';
 import PlanModule from './modules/plan/plan.module';
 import QuoteModule from './modules/quote/quote.module';
+import PaymentModule from './modules/payment/payment.module';
 
 @Module({
   imports: [
@@ -25,7 +26,8 @@ import QuoteModule from './modules/quote/quote.module';
     NotificationModule,
     FollowModule,
     PlanModule,
-    QuoteModule
+    QuoteModule,
+    PaymentModule
   ],
   controllers: [],
   providers: [

--- a/src/common/constants/errorMessage.enum.ts
+++ b/src/common/constants/errorMessage.enum.ts
@@ -1,4 +1,5 @@
 const enum ErrorMessage {
+  USER_UNAUTHORIZED = '접근 권한이 없습니다.',
   USER_NOT_FOUND = '해당 유저를 찾을 수 없습니다.',
   USER_EXIST = '이미 존재하는 이메일입니다.',
   USER_NICKNAME_EXIST = '이미 존재하는 닉네임입니다.',
@@ -41,6 +42,8 @@ const enum ErrorMessage {
   QUOTE_BAD_REQUEST_IS_CONFIRMED = 'isConfirmed는 boolean 값인 true와 false만 입력이 가능합니다.',
   QUOTE_CONFLICT = '해당 플랜에 이미 견적서를 작성하셨습니다. 하나의 플랜에는 하나의 견적서만 쓸 수 있습니다.',
   QUOTE_DELETE_BAD_REQUEST_STATUS = '견적의 플랜이 PENDING 상태 일 때만 삭제할 수 있습니다.',
+
+  PAYMENT_BAD_REQUEST = '결제 정보가 잘못되어 결제를 완료할 수 없습니다.',
 
   INTERNAL_SERVER_ERROR = '내부 서버 오류'
 }

--- a/src/common/constants/paymentStatus.type.ts
+++ b/src/common/constants/paymentStatus.type.ts
@@ -1,0 +1,6 @@
+export enum PaymentStatusEnum {
+  PENDING = 'PENDING',
+  COMPLETED = 'COMPLETED',
+  CANCELLED = 'CANCELLED',
+  PAID = 'PAID'
+}

--- a/src/common/domains/payment/payment.domain.ts
+++ b/src/common/domains/payment/payment.domain.ts
@@ -1,0 +1,50 @@
+import { PaymentStatusEnum } from 'src/common/constants/paymentStatus.type';
+import { PaymentProperties, PaymentToClientProperties } from 'src/common/types/payment/payment.type';
+import { IPayment } from './payment.interface';
+
+export default class Payment implements IPayment {
+  private readonly id?: string;
+  private readonly userId: string;
+  private readonly amount: number;
+  private status: PaymentStatusEnum;
+
+  constructor(payment: PaymentProperties) {
+    this.id = payment?.id;
+    this.userId = payment.userId;
+    this.amount = payment.amount;
+    this.status = payment.status;
+  }
+
+  static create(data: PaymentProperties) {
+    return new Payment(data);
+  }
+
+  update(status: PaymentStatusEnum): void {
+    this.status = status;
+  }
+
+  getId(): string {
+    return this.id;
+  }
+
+  getUserId(): string {
+    return this.userId;
+  }
+
+  get(): PaymentProperties {
+    return {
+      id: this.id,
+      userId: this.userId,
+      amount: this.amount,
+      status: this.status
+    };
+  }
+
+  toClient(): PaymentToClientProperties {
+    return {
+      id: this.id,
+      amount: this.amount,
+      status: this.status
+    };
+  }
+}

--- a/src/common/domains/payment/payment.interface.ts
+++ b/src/common/domains/payment/payment.interface.ts
@@ -1,0 +1,10 @@
+import { PaymentStatusEnum } from 'src/common/constants/paymentStatus.type';
+import { PaymentProperties, PaymentToClientProperties } from 'src/common/types/payment/payment.type';
+
+export interface IPayment {
+  update(status: PaymentStatusEnum): void;
+  getId(): string;
+  getUserId(): string;
+  get(): PaymentProperties;
+  toClient(): PaymentToClientProperties;
+}

--- a/src/common/domains/payment/payment.mapper.ts
+++ b/src/common/domains/payment/payment.mapper.ts
@@ -1,0 +1,21 @@
+import { PaymentProperties } from 'src/common/types/payment/payment.type';
+import Payment from './payment.domain';
+
+export default class PaymentMapper {
+  constructor(private readonly payment: PaymentProperties) {}
+
+  toDomain() {
+    if (!this.payment) {
+      return null;
+    }
+
+    return new Payment({
+      id: this.payment.id,
+      userId: this.payment.userId,
+      amount: this.payment.amount,
+      status: this.payment.status,
+      createdAt: this.payment.createdAt,
+      updatedAt: this.payment.updatedAt
+    });
+  }
+}

--- a/src/common/types/payment/payment.type.ts
+++ b/src/common/types/payment/payment.type.ts
@@ -1,0 +1,16 @@
+import { PaymentStatusEnum } from 'src/common/constants/paymentStatus.type';
+
+export interface PaymentProperties {
+  id?: string;
+  userId: string;
+  amount: number;
+  status: PaymentStatusEnum;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+export interface PaymentToClientProperties {
+  id: string;
+  amount: number;
+  status: PaymentStatusEnum;
+}

--- a/src/modules/payment/payment.controller.ts
+++ b/src/modules/payment/payment.controller.ts
@@ -1,0 +1,24 @@
+import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import PaymentService from './payment.service';
+import { UserId } from 'src/common/decorators/user.decorator';
+import { PaymentToClientProperties } from 'src/common/types/payment/payment.type';
+
+@Controller('payments')
+export default class PaymentController {
+  constructor(private readonly service: PaymentService) {}
+
+  @Get(':paymentId')
+  async getPayment(
+    @UserId() userId: string,
+    @Param('paymentId') paymentId: string
+  ): Promise<PaymentToClientProperties> {
+    return await this.service.get(userId, paymentId);
+  }
+
+  @Post()
+  async savePayment(@UserId() userId: string, @Body() body: { amount: number }): Promise<PaymentToClientProperties> {
+    return await this.service.create(userId, body);
+  }
+
+  // TODO: 결제 완료 API
+}

--- a/src/modules/payment/payment.module.ts
+++ b/src/modules/payment/payment.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import PaymentController from './payment.controller';
+import PaymentService from './payment.service';
+import PaymentRepository from './payment.repository';
+import PaymentSchema, { Payment } from 'src/providers/database/mongoose/payment.schema';
+import { MongooseModule } from '@nestjs/mongoose';
+
+@Module({
+  imports: [MongooseModule.forFeature([{ name: Payment.name, schema: PaymentSchema }])],
+  controllers: [PaymentController],
+  providers: [PaymentService, PaymentRepository],
+  exports: []
+})
+export default class PaymentModule {}

--- a/src/modules/payment/payment.repository.ts
+++ b/src/modules/payment/payment.repository.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { IPayment } from 'src/common/domains/payment/payment.interface';
+import PaymentMapper from 'src/common/domains/payment/payment.mapper';
+import { PaymentProperties } from 'src/common/types/payment/payment.type';
+import { Payment } from 'src/providers/database/mongoose/payment.schema';
+
+@Injectable()
+export default class PaymentRepository {
+  constructor(@InjectModel(Payment.name) private payment: Model<Payment>) {}
+
+  async findById(id: string): Promise<IPayment> {
+    const data = await this.payment.findById(id).exec();
+    const payment = { ...data.toObject(), id: data._id.toString() };
+
+    return new PaymentMapper(payment).toDomain();
+  }
+
+  async create(data: PaymentProperties): Promise<IPayment> {
+    const payment = await this.payment.create(data);
+
+    return new PaymentMapper(payment).toDomain();
+  }
+
+  async update(data: Partial<PaymentProperties>) {
+    const payment = await this.payment.findByIdAndUpdate(data.id, { $set: data }, { new: true });
+
+    return new PaymentMapper(payment).toDomain();
+  }
+}

--- a/src/modules/payment/payment.service.ts
+++ b/src/modules/payment/payment.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import PaymentRepository from './payment.repository';
+import { PaymentStatusEnum } from 'src/common/constants/paymentStatus.type';
+import { PaymentToClientProperties } from 'src/common/types/payment/payment.type';
+import Payment from 'src/common/domains/payment/payment.domain';
+import UnauthorizedError from 'src/common/errors/unauthorizedError';
+import ErrorMessage from 'src/common/constants/errorMessage.enum';
+
+@Injectable()
+export default class PaymentService {
+  constructor(private readonly repository: PaymentRepository) {}
+
+  async get(userId: string, paymentId: string): Promise<PaymentToClientProperties> {
+    const payment = await this.repository.findById(paymentId);
+    if (userId !== payment.getUserId()) {
+      throw new UnauthorizedError(ErrorMessage.USER_UNAUTHORIZED);
+    }
+
+    return payment.toClient();
+  }
+
+  async create(userId: string, data: { amount: number }): Promise<PaymentToClientProperties> {
+    const payment = new Payment({ userId, amount: data.amount, status: PaymentStatusEnum.PENDING });
+    const savedPayment = await this.repository.create(payment.get());
+
+    return savedPayment.toClient();
+  }
+}

--- a/src/providers/database/mongoose/payment.schema.ts
+++ b/src/providers/database/mongoose/payment.schema.ts
@@ -1,0 +1,23 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { HydratedDocument, Types } from 'mongoose';
+import { PaymentStatusEnum } from 'src/common/constants/paymentStatus.type';
+
+@Schema({ timestamps: true })
+export class Payment {
+  @Prop({ default: null })
+  isDeletedAt: Date | null;
+
+  @Prop({ type: String })
+  userId: string | null;
+
+  @Prop({ isRequired: true })
+  amount: number;
+
+  @Prop({ type: String, enum: PaymentStatusEnum, default: PaymentStatusEnum.PENDING })
+  status: PaymentStatusEnum;
+}
+
+export type PaymentDocument = HydratedDocument<Payment>;
+
+const PaymentSchema = SchemaFactory.createForClass(Payment);
+export default PaymentSchema;

--- a/src/providers/portOne/portone.module.ts
+++ b/src/providers/portOne/portone.module.ts
@@ -1,0 +1,19 @@
+import { DynamicModule, Module } from '@nestjs/common';
+import { PortOneService } from './portone.service';
+
+@Module({})
+export class PortOneModule {
+  static forRoot(secret: string): DynamicModule {
+    return {
+      module: PortOneModule,
+      providers: [
+        {
+          provide: 'PORTONE_SECRET',
+          useValue: secret
+        },
+        PortOneService
+      ],
+      exports: [PortOneService]
+    };
+  }
+}

--- a/src/providers/portOne/portone.provider.ts
+++ b/src/providers/portOne/portone.provider.ts
@@ -1,0 +1,13 @@
+import { Payment } from '@portone/server-sdk/dist/generated/payment';
+
+export interface PortOneProvider {
+  getPayment(paymentId: string): Promise<Payment | null>;
+  cancelPayment(paymentId: string, reason: string): Promise<boolean>;
+}
+
+export class GetPaymentError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PaymentError';
+  }
+}

--- a/src/providers/portOne/portone.service.ts
+++ b/src/providers/portOne/portone.service.ts
@@ -1,0 +1,34 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { GetPaymentError, PortOneProvider } from './portone.provider';
+import { PaymentClient } from '@portone/server-sdk';
+import ErrorMessage from 'src/common/constants/errorMessage.enum';
+import BadRequestError from 'src/common/errors/badRequestError';
+
+@Injectable()
+export class PortOneService implements PortOneProvider {
+  private client: PaymentClient;
+
+  constructor(@Inject('PORTONE_SECRET') private readonly secret: string) {
+    this.client = PaymentClient({ secret });
+  }
+
+  async getPayment(paymentId: string) {
+    try {
+      return await this.client.getPayment({ paymentId });
+    } catch (error) {
+      if (error instanceof GetPaymentError) {
+        return null;
+      }
+      throw new GetPaymentError(ErrorMessage.PAYMENT_BAD_REQUEST);
+    }
+  }
+
+  async cancelPayment(paymentId: string, reason: string): Promise<boolean> {
+    try {
+      await this.client.cancelPayment({ paymentId, reason });
+      return true;
+    } catch (error) {
+      throw new BadRequestError('결제를 취소하지 못했습니다');
+    }
+  }
+}


### PR DESCRIPTION
## 작업한 이슈 번호

- close #58 

## 작업 사항 설명
결제 생성 및 결제 상태 조회 API 구현
## 작업 사항

- [x] 결제 생성 API
- [x] 결제 조회 API

## 기타

- portOne provider 설정이 너무 오래 걸릴 것 같은데, 이것 때문에 타입 에러가 나서 작업해놓은 결제 완료 API(실제 결제 정보 연동 필요) 내용은 지우고 올립니다. 추후 다시 이어서 작업할 예정이라 provider 쪽 내용은 무시하셔도 되고, app.module.ts와 payment.module.ts 모두 연결하지 않은 상태입니다. 
- 결제 완료 API 및 웹훅 모두 추후 작업 예정

