### PR TITLE
유저가 찜한 Maker 목록 조회 API 구현

### DIFF
--- a/src/common/domains/follow/follow.domain.ts
+++ b/src/common/domains/follow/follow.domain.ts
@@ -1,17 +1,22 @@
-import { FollowProperties } from '../../types/follow/follow.types';
+import { UserReference } from 'src/common/types/user/user.types';
+import { FollowProperties, FollowPropertiesWithMaker } from '../../types/follow/follow.types';
 import IFollow from './follow.interface';
 
 export default class Follow implements IFollow {
   private readonly id?: string;
-  private makerId: string;
-  private dreamerId: string;
+  private readonly makerId: string;
+  private readonly maker?: UserReference;
+  private readonly dreamerId: string;
+  private readonly isFollowed?: boolean;
   private readonly createdAt?: Date;
   private readonly updatedAt?: Date;
 
-  constructor(follow: FollowProperties) {
+  constructor(follow: FollowPropertiesWithMaker) {
     this.id = follow?.id;
     this.makerId = follow.makerId;
+    this.maker = follow?.maker;
     this.dreamerId = follow.dreamerId;
+    this.isFollowed = follow?.isFollowed;
     this.createdAt = follow?.createdAt;
     this.updatedAt = follow?.updatedAt;
   }
@@ -20,11 +25,31 @@ export default class Follow implements IFollow {
     return new Follow(data);
   }
 
-  get() {
+  getMakerId(): string {
+    return this.makerId;
+  }
+
+  getMaker(): UserReference {
+    return this.maker;
+  }
+
+  toDB() {
     return {
       id: this.id,
       makerId: this.makerId,
       dreamerId: this.dreamerId,
+      createdAt: this.createdAt,
+      updatedAt: this.updatedAt
+    };
+  }
+
+  toClient() {
+    return {
+      id: this.id,
+      makerId: this.makerId,
+      maker: this.maker,
+      dreamerId: this.dreamerId,
+      isFollowed: this.isFollowed,
       createdAt: this.createdAt,
       updatedAt: this.updatedAt
     };

--- a/src/common/domains/follow/follow.interface.ts
+++ b/src/common/domains/follow/follow.interface.ts
@@ -1,5 +1,9 @@
-import { FollowProperties } from '../../types/follow/follow.types';
+import { UserReference } from 'src/common/types/user/user.types';
+import { FollowProperties, FollowPropertiesWithMaker } from '../../types/follow/follow.types';
 
 export default interface IFollow {
-  get(): FollowProperties;
+  getMakerId(): string;
+  getMaker(): UserReference;
+  toDB(): FollowProperties;
+  toClient(): FollowPropertiesWithMaker;
 }

--- a/src/common/domains/follow/follow.mapper.ts
+++ b/src/common/domains/follow/follow.mapper.ts
@@ -12,7 +12,8 @@ export default class FollowMapper {
       makerId: this.follow.makerId,
       maker: {
         nickName: this.follow?.maker?.nickName,
-        image: this.follow?.maker?.makerProfile.image
+        image: this.follow?.maker?.makerProfile.image,
+        gallery: this.follow?.maker?.makerProfile.gallery
       },
       isFollowed,
       dreamerId: this.follow.dreamerId,

--- a/src/common/domains/follow/follow.mapper.ts
+++ b/src/common/domains/follow/follow.mapper.ts
@@ -1,13 +1,20 @@
-import { FollowProperties } from '../../types/follow/follow.types';
+import { FollowPropertiesFromDB } from '../../types/follow/follow.types';
 import Follow from './follow.domain';
 
 export default class FollowMapper {
-  constructor(private readonly follow: FollowProperties) {}
+  constructor(private readonly follow: FollowPropertiesFromDB) {}
 
   toDomain() {
+    const isFollowed = this.follow.maker.followers.length > 0 ? true : false;
+
     return new Follow({
       id: this.follow.id,
       makerId: this.follow.makerId,
+      maker: {
+        nickName: this.follow?.maker?.nickName,
+        image: this.follow?.maker?.makerProfile.image
+      },
+      isFollowed,
       dreamerId: this.follow.dreamerId,
       createdAt: this.follow.createdAt,
       updatedAt: this.follow.updatedAt

--- a/src/common/domains/userStats/userStats.domain.ts
+++ b/src/common/domains/userStats/userStats.domain.ts
@@ -59,4 +59,13 @@ export default class UserStats implements IUserStats {
       totalConfirms: this.totalConfirms
     };
   }
+
+  isValidStats(): boolean {
+    return (
+      this.averageRating !== undefined &&
+      this.totalReviews !== undefined &&
+      this.totalFollows !== undefined &&
+      this.totalConfirms !== undefined
+    );
+  }
 }

--- a/src/common/domains/userStats/userStats.interface.ts
+++ b/src/common/domains/userStats/userStats.interface.ts
@@ -4,4 +4,5 @@ export interface IUserStats {
   update(data: Partial<UserStatsProperties>): void;
   get(): UserStatsProperties;
   toObject(): UserStatsToClientProperties;
+  isValidStats(): boolean;
 }

--- a/src/common/types/follow/follow.dto.ts
+++ b/src/common/types/follow/follow.dto.ts
@@ -1,0 +1,12 @@
+import { Type } from 'class-transformer';
+import { IsInt } from 'class-validator';
+
+export class GetFollowQueryDTO {
+  @Type(() => Number)
+  @IsInt()
+  page: number = 1;
+
+  @Type(() => Number)
+  @IsInt()
+  pageSize: number = 10;
+}

--- a/src/common/types/follow/follow.types.ts
+++ b/src/common/types/follow/follow.types.ts
@@ -11,7 +11,7 @@ export interface FollowProperties {
 export interface FollowPropertiesWithMaker {
   id?: string;
   makerId: string;
-  maker?: { nickName: string; image: ProfileImage };
+  maker?: { nickName: string; image: ProfileImage; gallery: string };
   dreamerId: string;
   isFollowed?: boolean;
   createdAt?: Date;
@@ -23,7 +23,7 @@ export interface FollowPropertiesFromDB {
   makerId: string;
   maker?: {
     nickName: string;
-    makerProfile: { image: ProfileImage };
+    makerProfile: { image: ProfileImage; gallery: string };
     followers: { id: string }[];
   };
   dreamerId: string;

--- a/src/common/types/follow/follow.types.ts
+++ b/src/common/types/follow/follow.types.ts
@@ -1,7 +1,41 @@
+import { ProfileImage } from 'src/common/constants/image.type';
+
 export interface FollowProperties {
   id?: string;
   makerId: string;
   dreamerId: string;
   createdAt?: Date;
   updatedAt?: Date;
+}
+
+export interface FollowPropertiesWithMaker {
+  id?: string;
+  makerId: string;
+  maker?: { nickName: string; image: ProfileImage };
+  dreamerId: string;
+  isFollowed?: boolean;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+export interface FollowPropertiesFromDB {
+  id?: string;
+  makerId: string;
+  maker?: {
+    nickName: string;
+    makerProfile: { image: ProfileImage };
+    followers: { id: string }[];
+  };
+  dreamerId: string;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+export interface FollowPropertiesToClient extends FollowPropertiesWithMaker {
+  userStats: {
+    averageRating: number;
+    totalReviews: number;
+    totalFollows: number;
+    totalConfirms: number;
+  };
 }

--- a/src/common/types/user/user.types.ts
+++ b/src/common/types/user/user.types.ts
@@ -1,3 +1,4 @@
+import { ProfileImage } from 'src/common/constants/image.type';
 import { Role } from 'src/common/constants/role.type';
 
 export interface UserProperties {
@@ -22,4 +23,9 @@ export interface FilteredUserProperties {
 export interface PasswordProperties {
   password: string;
   newPassword: string;
+}
+
+export interface UserReference {
+  nickName: string;
+  image: ProfileImage;
 }

--- a/src/common/types/user/user.types.ts
+++ b/src/common/types/user/user.types.ts
@@ -28,4 +28,5 @@ export interface PasswordProperties {
 export interface UserReference {
   nickName: string;
   image: ProfileImage;
+  gallery: string;
 }

--- a/src/modules/follow/follow.controller.ts
+++ b/src/modules/follow/follow.controller.ts
@@ -1,7 +1,8 @@
-import { Body, Controller, Delete, Get, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import { Body, Controller, Delete, Get, HttpCode, HttpStatus, Post, Query } from '@nestjs/common';
 import FollowService from './follow.service';
 import { UserId } from 'src/common/decorators/user.decorator';
 import { Role } from 'src/common/decorators/roleGuard.decorator';
+import { GetFollowQueryDTO } from 'src/common/types/follow/follow.dto';
 
 @Controller('follow')
 @Role('DREAMER')
@@ -9,8 +10,8 @@ export default class FollowController {
   constructor(private readonly service: FollowService) {}
 
   @Get()
-  async getFollowList(@UserId() userId: string) {
-    return await this.service.get(userId);
+  async getFollowList(@UserId() userId: string, @Query() options: GetFollowQueryDTO) {
+    return await this.service.get(userId, options);
   }
 
   @Post()

--- a/src/modules/follow/follow.controller.ts
+++ b/src/modules/follow/follow.controller.ts
@@ -3,6 +3,7 @@ import FollowService from './follow.service';
 import { UserId } from 'src/common/decorators/user.decorator';
 import { Role } from 'src/common/decorators/roleGuard.decorator';
 import { GetFollowQueryDTO } from 'src/common/types/follow/follow.dto';
+import { FollowProperties } from 'src/common/types/follow/follow.types';
 
 @Controller('follow')
 @Role('DREAMER')
@@ -10,7 +11,10 @@ export default class FollowController {
   constructor(private readonly service: FollowService) {}
 
   @Get()
-  async getFollowList(@UserId() userId: string, @Query() options: GetFollowQueryDTO) {
+  async getFollowList(
+    @UserId() userId: string,
+    @Query() options: GetFollowQueryDTO
+  ): Promise<{ totalCount: number; list: FollowProperties[] }> {
     return await this.service.get(userId, options);
   }
 

--- a/src/modules/follow/follow.controller.ts
+++ b/src/modules/follow/follow.controller.ts
@@ -1,10 +1,17 @@
-import { Body, Controller, Delete, HttpCode, HttpStatus, Post, Res } from '@nestjs/common';
+import { Body, Controller, Delete, Get, HttpCode, HttpStatus, Post } from '@nestjs/common';
 import FollowService from './follow.service';
 import { UserId } from 'src/common/decorators/user.decorator';
+import { Role } from 'src/common/decorators/roleGuard.decorator';
 
 @Controller('follow')
+@Role('DREAMER')
 export default class FollowController {
   constructor(private readonly service: FollowService) {}
+
+  @Get()
+  async getFollowList(@UserId() userId: string) {
+    return await this.service.get(userId);
+  }
 
   @Post()
   @HttpCode(HttpStatus.NO_CONTENT)

--- a/src/modules/follow/follow.module.ts
+++ b/src/modules/follow/follow.module.ts
@@ -3,13 +3,12 @@ import PrismaModule from 'src/providers/database/prisma/prisma.module';
 import FollowRepository from './follow.repository';
 import FollowController from './follow.controller';
 import FollowService from './follow.service';
-import RedisService from 'src/providers/cache/redis.service';
 import UserStatsModule from '../userStats/userStats.module';
 
 @Module({
   imports: [PrismaModule, UserStatsModule],
   controllers: [FollowController],
-  providers: [FollowService, FollowRepository, RedisService],
+  providers: [FollowService, FollowRepository],
   exports: []
 })
 export default class FollowModule {}

--- a/src/modules/follow/follow.module.ts
+++ b/src/modules/follow/follow.module.ts
@@ -3,11 +3,12 @@ import PrismaModule from 'src/providers/database/prisma/prisma.module';
 import FollowRepository from './follow.repository';
 import FollowController from './follow.controller';
 import FollowService from './follow.service';
+import RedisService from 'src/providers/cache/redis.service';
 
 @Module({
   imports: [PrismaModule],
   controllers: [FollowController],
-  providers: [FollowService, FollowRepository],
+  providers: [FollowService, FollowRepository, RedisService],
   exports: []
 })
 export default class FollowModule {}

--- a/src/modules/follow/follow.module.ts
+++ b/src/modules/follow/follow.module.ts
@@ -4,9 +4,10 @@ import FollowRepository from './follow.repository';
 import FollowController from './follow.controller';
 import FollowService from './follow.service';
 import RedisService from 'src/providers/cache/redis.service';
+import UserStatsModule from '../userStats/userStats.module';
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, UserStatsModule],
   controllers: [FollowController],
   providers: [FollowService, FollowRepository, RedisService],
   exports: []

--- a/src/modules/follow/follow.repository.ts
+++ b/src/modules/follow/follow.repository.ts
@@ -27,8 +27,6 @@ export default class FollowRepository {
         }
       }
     });
-    console.log(JSON.stringify(data, null, 2));
-
     return data.map((follow) => new FollowMapper(follow).toDomain());
   }
 
@@ -44,7 +42,6 @@ export default class FollowRepository {
 
   async create(data: Partial<FollowProperties>): Promise<null> {
     await this.db.follow.create({ data });
-    console.log('db created');
     return;
   }
 

--- a/src/modules/follow/follow.repository.ts
+++ b/src/modules/follow/follow.repository.ts
@@ -8,6 +8,30 @@ import IFollow from '../../common/domains/follow/follow.interface';
 export default class FollowRepository {
   constructor(private readonly db: DBClient) {}
 
+  async get(dreamerId: string) {
+    const data = await this.db.follow.findMany({
+      where: { dreamerId },
+      select: {
+        id: true,
+        makerId: true,
+        dreamerId: true,
+        maker: {
+          select: {
+            nickName: true,
+            makerProfile: { select: { image: true } },
+            followers: {
+              where: { dreamerId },
+              select: { id: true }
+            }
+          }
+        }
+      }
+    });
+    console.log(JSON.stringify(data, null, 2));
+
+    return data.map((follow) => new FollowMapper(follow).toDomain());
+  }
+
   async find(dreamerId: string, makerId: string): Promise<IFollow> {
     const data = await this.db.follow.findFirst({
       where: { dreamerId, makerId }
@@ -20,6 +44,7 @@ export default class FollowRepository {
 
   async create(data: Partial<FollowProperties>): Promise<null> {
     await this.db.follow.create({ data });
+    console.log('db created');
     return;
   }
 

--- a/src/modules/follow/follow.repository.ts
+++ b/src/modules/follow/follow.repository.ts
@@ -23,7 +23,7 @@ export default class FollowRepository {
         maker: {
           select: {
             nickName: true,
-            makerProfile: { select: { image: true } },
+            makerProfile: { select: { image: true, gallery: true } },
             followers: {
               where: { dreamerId },
               select: { id: true }

--- a/src/modules/follow/follow.repository.ts
+++ b/src/modules/follow/follow.repository.ts
@@ -3,14 +3,19 @@ import DBClient from 'src/providers/database/prisma/DB.client';
 import FollowMapper from '../../common/domains/follow/follow.mapper';
 import { FollowProperties } from '../../common/types/follow/follow.types';
 import IFollow from '../../common/domains/follow/follow.interface';
+import { GetFollowQueryDTO } from 'src/common/types/follow/follow.dto';
 
 @Injectable()
 export default class FollowRepository {
   constructor(private readonly db: DBClient) {}
 
-  async get(dreamerId: string) {
+  async get(dreamerId: string, options: GetFollowQueryDTO) {
+    const { page, pageSize } = options;
+
     const data = await this.db.follow.findMany({
       where: { dreamerId },
+      take: pageSize,
+      skip: pageSize * (page - 1),
       select: {
         id: true,
         makerId: true,
@@ -28,6 +33,10 @@ export default class FollowRepository {
       }
     });
     return data.map((follow) => new FollowMapper(follow).toDomain());
+  }
+
+  async count(dreamerId: string) {
+    return await this.db.follow.count({ where: { dreamerId } });
   }
 
   async find(dreamerId: string, makerId: string): Promise<IFollow> {

--- a/src/modules/follow/follow.service.ts
+++ b/src/modules/follow/follow.service.ts
@@ -5,6 +5,7 @@ import ErrorMessage from 'src/common/constants/errorMessage.enum';
 import Follow from '../../common/domains/follow/follow.domain';
 import UserStatsService from '../userStats/userStats.service';
 import { GetFollowQueryDTO } from 'src/common/types/follow/follow.dto';
+import { FollowProperties } from 'src/common/types/follow/follow.types';
 
 @Injectable()
 export default class FollowService {
@@ -13,10 +14,10 @@ export default class FollowService {
     private readonly userStats: UserStatsService
   ) {}
 
-  async get(userId: string, options: GetFollowQueryDTO) {
+  async get(userId: string, options: GetFollowQueryDTO): Promise<{ totalCount: number; list: FollowProperties[] }> {
     const follows = await this.repository.get(userId, options);
 
-    const followList = await Promise.all(
+    const list = await Promise.all(
       follows.map(async (follow) => {
         const makerStats = await this.userStats.get(follow.getMakerId());
         const followData = follow.toClient();
@@ -25,7 +26,9 @@ export default class FollowService {
       })
     );
 
-    return followList;
+    const totalCount = await this.repository.count(userId);
+
+    return { totalCount, list };
   }
 
   // 찜 기능: Dreamer -> Maker

--- a/src/modules/follow/follow.service.ts
+++ b/src/modules/follow/follow.service.ts
@@ -4,12 +4,14 @@ import BadRequestError from 'src/common/errors/badRequestError';
 import ErrorMessage from 'src/common/constants/errorMessage.enum';
 import Follow from '../../common/domains/follow/follow.domain';
 import RedisService from 'src/providers/cache/redis.service';
+import UserStatsService from '../userStats/userStats.service';
 
 @Injectable()
 export default class FollowService {
   constructor(
     private readonly repository: FollowRepository,
-    private readonly redis: RedisService
+    private readonly redis: RedisService,
+    private readonly userStats: UserStatsService
   ) {}
 
   async get(userId: string) {
@@ -17,19 +19,16 @@ export default class FollowService {
 
     const followList = await Promise.all(
       follows.map(async (follow) => {
-        const makerStats = await this.redis.getStats(follow.getMakerId());
-        const followData = follow.toClient();
-        if (makerStats === null) {
-          return {
-            ...followData,
-            makerStats: {
-              totalReviews: 0,
-              averageRating: 0,
-              totalFollows: 0,
-              totalConfirms: 0
-            }
-          };
+        let makerStats = await this.redis.getStats(follow.getMakerId());
+        if (!makerStats) {
+          makerStats = await this.userStats.get(follow.getMakerId());
+          if (!makerStats) {
+            makerStats = { totalReviews: 0, averageRating: 0, totalFollows: 0, totalConfirms: 0 };
+          }
+          await this.redis.cacheStats(userId, makerStats);
         }
+        const followData = follow.toClient();
+
         return { ...followData, makerStats };
       })
     );

--- a/src/modules/follow/follow.service.ts
+++ b/src/modules/follow/follow.service.ts
@@ -21,7 +21,7 @@ export default class FollowService {
         const makerStats = await this.userStats.get(follow.getMakerId());
         const followData = follow.toClient();
 
-        return { ...followData, makerStats };
+        return { ...followData, maker: { ...followData.maker, ...makerStats } };
       })
     );
 

--- a/src/modules/follow/follow.service.ts
+++ b/src/modules/follow/follow.service.ts
@@ -5,6 +5,7 @@ import ErrorMessage from 'src/common/constants/errorMessage.enum';
 import Follow from '../../common/domains/follow/follow.domain';
 import RedisService from 'src/providers/cache/redis.service';
 import UserStatsService from '../userStats/userStats.service';
+import { GetFollowQueryDTO } from 'src/common/types/follow/follow.dto';
 
 @Injectable()
 export default class FollowService {
@@ -14,8 +15,8 @@ export default class FollowService {
     private readonly userStats: UserStatsService
   ) {}
 
-  async get(userId: string) {
-    const follows = await this.repository.get(userId);
+  async get(userId: string, options: GetFollowQueryDTO) {
+    const follows = await this.repository.get(userId, options);
 
     const followList = await Promise.all(
       follows.map(async (follow) => {

--- a/src/modules/follow/follow.service.ts
+++ b/src/modules/follow/follow.service.ts
@@ -3,10 +3,39 @@ import FollowRepository from './follow.repository';
 import BadRequestError from 'src/common/errors/badRequestError';
 import ErrorMessage from 'src/common/constants/errorMessage.enum';
 import Follow from '../../common/domains/follow/follow.domain';
+import RedisService from 'src/providers/cache/redis.service';
 
 @Injectable()
 export default class FollowService {
-  constructor(private readonly repository: FollowRepository) {}
+  constructor(
+    private readonly repository: FollowRepository,
+    private readonly redis: RedisService
+  ) {}
+
+  async get(userId: string) {
+    const follows = await this.repository.get(userId);
+
+    const followList = await Promise.all(
+      follows.map(async (follow) => {
+        const makerStats = await this.redis.getStats(follow.getMakerId());
+        const followData = follow.toClient();
+        if (makerStats === null) {
+          return {
+            ...followData,
+            makerStats: {
+              totalReviews: 0,
+              averageRating: 0,
+              totalFollows: 0,
+              totalConfirms: 0
+            }
+          };
+        }
+        return { ...followData, makerStats };
+      })
+    );
+
+    return followList;
+  }
 
   // 찜 기능: Dreamer -> Maker
   async create(dreamerId: string, makerId: string): Promise<null> {
@@ -17,7 +46,7 @@ export default class FollowService {
     }
 
     const data = new Follow({ dreamerId, makerId });
-    return await this.repository.create(data.get());
+    return await this.repository.create(data.toDB());
   }
 
   async delete(dreamerId: string, makerId: string): Promise<null> {
@@ -27,6 +56,6 @@ export default class FollowService {
       throw new BadRequestError(ErrorMessage.FOLLOW_NOT_FOUND);
     }
 
-    return await this.repository.delete(follow.get().id);
+    return await this.repository.delete(follow.toDB().id);
   }
 }

--- a/src/modules/userStats/userStats.module.ts
+++ b/src/modules/userStats/userStats.module.ts
@@ -7,6 +7,6 @@ import UserStatsRepository from './userStats.repository';
 @Module({
   imports: [MongooseModule.forFeature([{ name: UserStats.name, schema: UserStatsSchema }])],
   providers: [UserStatsRepository, UserStatsService],
-  exports: [UserStatsService]
+  exports: [UserStatsService, UserStatsRepository]
 })
 export default class UserStatsModule {}

--- a/src/modules/userStats/userStats.module.ts
+++ b/src/modules/userStats/userStats.module.ts
@@ -3,10 +3,11 @@ import UserStatsService from './userStats.service';
 import UserStatsSchema, { UserStats } from 'src/providers/database/mongoose/userStats.schema';
 import { MongooseModule } from '@nestjs/mongoose';
 import UserStatsRepository from './userStats.repository';
+import RedisService from 'src/providers/cache/redis.service';
 
 @Module({
   imports: [MongooseModule.forFeature([{ name: UserStats.name, schema: UserStatsSchema }])],
-  providers: [UserStatsRepository, UserStatsService],
+  providers: [UserStatsRepository, UserStatsService, RedisService],
   exports: [UserStatsService, UserStatsRepository]
 })
 export default class UserStatsModule {}

--- a/src/modules/userStats/userStats.service.ts
+++ b/src/modules/userStats/userStats.service.ts
@@ -16,10 +16,11 @@ export default class UserStatsService {
   async get(userId: string): Promise<UserStatsToClientProperties> {
     const stats = await this.redis.getStats(userId);
     let user: IUserStats = new UserStatsMapper({ ...stats, userId }).toDomain();
-    if (!user) {
+
+    if (!user.isValidStats()) {
       user = await this.repository.getByUserId(userId);
       if (!user) {
-        user = UserStats.create({ userId, totalReviews: 0, averageRating: 0, totalFollows: 0, totalConfirms: 0 });
+        user = UserStats.create({ userId });
       }
       await this.redis.cacheStats(userId, user.toObject());
     }

--- a/src/modules/userStats/userStats.service.ts
+++ b/src/modules/userStats/userStats.service.ts
@@ -2,15 +2,29 @@ import { Injectable } from '@nestjs/common';
 import UserStatsRepository from './userStats.repository';
 import UserStats from 'src/common/domains/userStats/userStats.domain';
 import { UserStatsProperties, UserStatsToClientProperties } from 'src/common/types/userStats/userStats.types';
+import RedisService from 'src/providers/cache/redis.service';
+import UserStatsMapper from 'src/common/domains/userStats/userStats.mapper';
+import { IUserStats } from 'src/common/domains/userStats/userStats.interface';
 
 @Injectable()
 export default class UserStatsService {
-  constructor(private readonly repository: UserStatsRepository) {}
+  constructor(
+    private readonly repository: UserStatsRepository,
+    private readonly redis: RedisService
+  ) {}
 
   async get(userId: string): Promise<UserStatsToClientProperties> {
-    const user = await this.repository.getByUserId(userId);
+    const stats = await this.redis.getStats(userId);
+    let user: IUserStats = new UserStatsMapper({ ...stats, userId }).toDomain();
+    if (!user) {
+      user = await this.repository.getByUserId(userId);
+      if (!user) {
+        user = UserStats.create({ userId, totalReviews: 0, averageRating: 0, totalFollows: 0, totalConfirms: 0 });
+      }
+      await this.redis.cacheStats(userId, user.toObject());
+    }
 
-    return user?.toObject();
+    return user.toObject();
   }
 
   async update(userId: string, data: Partial<UserStatsProperties>): Promise<UserStatsToClientProperties> {

--- a/src/providers/cache/bullmq.processor.ts
+++ b/src/providers/cache/bullmq.processor.ts
@@ -26,7 +26,7 @@ export class UserStatsProcessor extends WorkerHost {
       if (!stats) {
         stats = { totalReviews: 0, averageRating: 0, totalFollows: 0, totalConfirms: 0 };
       }
-      const x = await this.redis.cacheStats(userId, stats);
+      await this.redis.cacheStats(userId, stats);
     }
 
     // 2. 데이터 계산

--- a/src/providers/cache/bullmq.processor.ts
+++ b/src/providers/cache/bullmq.processor.ts
@@ -20,14 +20,7 @@ export class UserStatsProcessor extends WorkerHost {
     const { userId, event, rating, isAdd } = job.data;
 
     // 1. 데이터 조회
-    let stats = await this.redis.getStats(userId);
-    if (!stats) {
-      stats = await this.StatsService.get(userId);
-      if (!stats) {
-        stats = { totalReviews: 0, averageRating: 0, totalFollows: 0, totalConfirms: 0 };
-      }
-      await this.redis.cacheStats(userId, stats);
-    }
+    const stats = await this.StatsService.get(userId);
 
     // 2. 데이터 계산
     switch (event) {


### PR DESCRIPTION
## 작업한 이슈 번호

- close #70 

## 작업 사항 설명

유저가 찜한 Maker를 목록을 조회합니다.

## 작업 사항

- [x] 찜한 Maker 목록 조회 API
- [x] Maker 프로필에 profile image, nickName, makerStats 포함

## 기타

**[GET] /follow?page=1&pageSize=10** (페이지네이션 기본값)
```
{
  "totalCount": 2,
  "list": [
    {
      "id": "0aae2257-53e2-4d88-b408-d885f56a3dff",
      "makerId": "6b4ded82-e680-410d-b86d-ce6974e53f37",
      "maker": {
        "nickName": "무궁화",
        "image": "DEFAULT_1",
        "gallery": "https://www.instagram.com/codeit_kr/",
        "averageRating": 5,
        "totalReviews": 3,
        "totalFollows": 4,
        "totalConfirms": 3
      },
      "dreamerId": "555d463e-37b6-410b-9061-11a9d6822bdd",
      "isFollowed": true
    },
    {
      "id": "712e71af-be01-4bb9-992f-c66d6a10c5e7",
      "makerId": "a08d9856-adfa-4f83-9e9a-48401f3d0ef3",
      "maker": {
        "nickName": "개나리",
        "image": "DEFAULT_2",
        "gallery": "https://www.instagram.com/codeit_kr/",
        "averageRating": 4,
        "totalReviews": 1,
        "totalFollows": 5,
        "totalConfirms": 2
      },
      "dreamerId": "555d463e-37b6-410b-9061-11a9d6822bdd",
      "isFollowed": true
    }
  ]
}
```