### PR TITLE
Maker 리뷰 목록 조회 API 구현

### DIFF
--- a/src/common/domains/review/review.domain.ts
+++ b/src/common/domains/review/review.domain.ts
@@ -35,7 +35,18 @@ export default class Review {
 
   toDB() {
     return {
-      id: this.id,
+      id: this?.id,
+      writerId: this.writerId,
+      ownerId: this.ownerId,
+      rating: this.rating,
+      content: this.content,
+      planId: this.planId
+    };
+  }
+
+  toClient() {
+    return {
+      id: this?.id,
       writerId: this.writerId,
       ownerId: this.ownerId,
       rating: this.rating,
@@ -43,6 +54,16 @@ export default class Review {
       planId: this.planId,
       createdAt: this.createdAt,
       updatedAt: this.updatedAt
+    };
+  }
+
+  toMakerProfile() {
+    return {
+      id: this?.id,
+      writer: this.writer,
+      rating: this.rating,
+      content: this.content,
+      createdAt: this.createdAt
     };
   }
 }

--- a/src/common/domains/review/review.interface.ts
+++ b/src/common/domains/review/review.interface.ts
@@ -1,5 +1,7 @@
-import { ReviewProperties } from 'src/common/types/review/review.types';
+import { ReviewAllProperties, ReviewProperties } from 'src/common/types/review/review.types';
 
 export default interface IReview {
   toDB(): ReviewProperties;
+  toClient(): ReviewProperties;
+  toMakerProfile(): ReviewAllProperties;
 }

--- a/src/common/domains/review/review.mapper.ts
+++ b/src/common/domains/review/review.mapper.ts
@@ -5,16 +5,18 @@ export default class ReviewMapper {
   constructor(private readonly review: ReviewAllProperties) {}
 
   toDomain() {
+    if (!this.review) return null;
+
     return new Review({
       id: this.review.id,
-      writerId: this.review.writerId,
-      writer: this.review.writer,
-      ownerId: this.review.ownerId,
+      writerId: this.review?.writerId,
+      writer: this.review?.writer,
+      ownerId: this.review?.ownerId,
       rating: this.review.rating,
       content: this.review.content,
-      planId: this.review.planId,
+      planId: this.review?.planId,
       createdAt: this.review.createdAt,
-      updatedAt: this.review.updatedAt
+      updatedAt: this.review?.updatedAt
     });
   }
 }

--- a/src/common/types/follow/follow.types.ts
+++ b/src/common/types/follow/follow.types.ts
@@ -1,4 +1,5 @@
 import { ProfileImage } from 'src/common/constants/image.type';
+import { UserReference } from '../user/user.types';
 
 export interface FollowProperties {
   id?: string;
@@ -11,7 +12,7 @@ export interface FollowProperties {
 export interface FollowPropertiesWithMaker {
   id?: string;
   makerId: string;
-  maker?: { nickName: string; image: ProfileImage; gallery: string };
+  maker?: UserReference;
   dreamerId: string;
   isFollowed?: boolean;
   createdAt?: Date;

--- a/src/common/types/review/review.dto.ts
+++ b/src/common/types/review/review.dto.ts
@@ -1,4 +1,5 @@
 import { IsInt, IsNotEmpty, IsPositive, IsString, IsUUID } from 'class-validator';
+import { Type } from 'class-transformer';
 
 export class CreateReviewDTO {
   @IsUUID()
@@ -17,4 +18,14 @@ export class CreateReviewDTO {
   @IsUUID()
   @IsNotEmpty()
   planId: string;
+}
+
+export class GetReviewsQueryDTO {
+  @Type(() => Number)
+  @IsInt()
+  page: number = 1;
+
+  @Type(() => Number)
+  @IsInt()
+  pageSize: number = 5;
 }

--- a/src/common/types/review/review.types.ts
+++ b/src/common/types/review/review.types.ts
@@ -14,13 +14,13 @@ export interface ReviewProperties {
 
 export interface ReviewAllProperties {
   id?: string;
-  writerId: string;
+  writerId?: string;
   writer?: UserReference;
-  ownerId: string;
+  ownerId?: string;
   owner?: UserReference;
   rating: number;
   content: string;
-  planId: string;
+  planId?: string;
   plan?: PlanReference;
   createdAt?: Date;
   updatedAt?: Date;

--- a/src/common/types/user/user.types.ts
+++ b/src/common/types/user/user.types.ts
@@ -1,5 +1,6 @@
 import { ProfileImage } from 'src/common/constants/image.type';
 import { Role } from 'src/common/constants/role.type';
+import { TripType } from 'src/common/constants/tripType.type';
 
 export interface UserProperties {
   id?: string;
@@ -27,6 +28,7 @@ export interface PasswordProperties {
 
 export interface UserReference {
   nickName: string;
-  image: ProfileImage;
-  gallery: string;
+  image?: ProfileImage;
+  gallery?: string;
+  serviceTypes?: TripType[];
 }

--- a/src/modules/review/review.controller.ts
+++ b/src/modules/review/review.controller.ts
@@ -1,15 +1,24 @@
-import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
 import ReviewService from './review.service';
 import { UserId } from 'src/common/decorators/user.decorator';
-import { CreateReviewDTO } from 'src/common/types/review/review.dto';
+import { CreateReviewDTO, GetReviewsQueryDTO } from 'src/common/types/review/review.dto';
+import { ReviewProperties } from 'src/common/types/review/review.types';
+import { Role } from 'src/common/decorators/roleGuard.decorator';
+import { Public } from 'src/common/decorators/public.decorator';
 
 @Controller('reviews')
 export default class ReviewController {
   constructor(private readonly service: ReviewService) {}
 
+  @Public()
+  @Get('maker/:makerId')
+  async getReviewByMaker(@Param('makerId') makerId: string, @Query() options: GetReviewsQueryDTO) {
+    return await this.service.getByUser(makerId, options);
+  }
+
   @Post()
-  @HttpCode(HttpStatus.NO_CONTENT)
-  async createReview(@UserId() writerId: string, @Body() data: CreateReviewDTO): Promise<void> {
+  @Role('DREAMER')
+  async createReview(@UserId() writerId: string, @Body() data: CreateReviewDTO): Promise<ReviewProperties> {
     return await this.service.create(writerId, data);
   }
 }

--- a/src/modules/review/review.repository.ts
+++ b/src/modules/review/review.repository.ts
@@ -1,11 +1,53 @@
 import { Injectable } from '@nestjs/common';
 import IReview from 'src/common/domains/review/review.interface';
 import ReviewMapper from 'src/common/domains/review/review.mapper';
+import { GetReviewsQueryDTO } from 'src/common/types/review/review.dto';
 import DBClient from 'src/providers/database/prisma/DB.client';
 
 @Injectable()
 export default class ReviewRepository {
   constructor(private readonly db: DBClient) {}
+
+  async getByUser(ownerId: string, options: GetReviewsQueryDTO): Promise<IReview[]> {
+    const { page, pageSize } = options;
+
+    const reviews = await this.db.review.findMany({
+      where: { ownerId },
+      take: pageSize,
+      skip: pageSize * (page - 1),
+      select: {
+        id: true,
+        createdAt: true,
+        rating: true,
+        content: true,
+        writer: { select: { nickName: true } }
+      }
+    });
+
+    return reviews.map((review) => new ReviewMapper(review).toDomain());
+  }
+
+  async count(userId: string, isDreamer: boolean): Promise<number> {
+    const where = isDreamer ? { writerId: userId } : { ownerId: userId };
+    const totalCount = await this.db.review.count({ where });
+
+    return totalCount;
+  }
+
+  async countByRating(ownerId: string): Promise<{ rating: number; count: number }[]> {
+    const groupByCount = await this.db.review.groupBy({
+      by: ['rating'],
+      where: { ownerId },
+      _count: { id: true }
+    });
+
+    const formattedGroupByCount = groupByCount.map((group) => ({
+      rating: group.rating,
+      count: group._count.id
+    }));
+
+    return formattedGroupByCount;
+  }
 
   async create(data: IReview): Promise<IReview> {
     const review = await this.db.review.create({ data: data.toDB() });


### PR DESCRIPTION
## 작업한 이슈 번호

- close #107 

## 작업 사항 설명

Maker에게 작성된 리뷰 목록을 조회하는 API를 구현합니다.



## 작업 사항

- [x] getReviewByMaker API 생성

## 기타

- 지난 PR 리뷰에 이야기한 '리뷰 생성 API' 응답 데이터 반환도 수정했습니다.

```
{
  "totalCount": 2,
  "groupByCount": [
    {
      "rating": 4,
      "count": 2
    }
  ],
  "list": [
    {
      "id": "919ddc45-5d2c-4efa-8c5d-5e7f8c6838d2",
      "writer": {
        "nickName": "하마"
      },
      "rating": 4,
      "content": "완벽한 대리 여행이었어요! 덕분에 좋은 경험이었습니다 :)",
      "createdAt": "2025-01-23T12:35:23.970Z"
    },
    {
      "id": "c48f3180-50ad-46be-9643-41a4664e6a7f",
      "writer": {
        "nickName": "호랑이"
      },
      "rating": 4,
      "content": "완벽한 대리 여행이었어요! 덕분에 좋은 경험이었습니다 :)",
      "createdAt": "2025-01-23T12:50:57.574Z"
    }
  ]
}
```
