### PR TITLE
내가 작성한 리뷰 목록 조회 API 구현

### DIFF
--- a/src/common/domains/review/review.domain.ts
+++ b/src/common/domains/review/review.domain.ts
@@ -57,10 +57,20 @@ export default class Review {
     };
   }
 
-  toMakerProfile() {
+  toMaker() {
     return {
       id: this?.id,
       writer: this.writer,
+      rating: this.rating,
+      content: this.content,
+      createdAt: this.createdAt
+    };
+  }
+  toDreamer() {
+    return {
+      id: this?.id,
+      owner: this.owner,
+      plan: this.plan,
       rating: this.rating,
       content: this.content,
       createdAt: this.createdAt

--- a/src/common/domains/review/review.interface.ts
+++ b/src/common/domains/review/review.interface.ts
@@ -3,5 +3,6 @@ import { ReviewAllProperties, ReviewProperties } from 'src/common/types/review/r
 export default interface IReview {
   toDB(): ReviewProperties;
   toClient(): ReviewProperties;
-  toMakerProfile(): ReviewAllProperties;
+  toMaker(): ReviewAllProperties;
+  toDreamer(): ReviewAllProperties;
 }

--- a/src/common/domains/review/review.mapper.ts
+++ b/src/common/domains/review/review.mapper.ts
@@ -9,14 +9,16 @@ export default class ReviewMapper {
 
     return new Review({
       id: this.review.id,
-      writerId: this.review?.writerId,
-      writer: this.review?.writer,
-      ownerId: this.review?.ownerId,
+      writerId: this.review.writerId,
+      writer: this.review.writer,
+      ownerId: this.review.ownerId,
+      owner: this.review.owner,
       rating: this.review.rating,
       content: this.review.content,
-      planId: this.review?.planId,
+      planId: this.review.planId,
+      plan: this.review.plan,
       createdAt: this.review.createdAt,
-      updatedAt: this.review?.updatedAt
+      updatedAt: this.review.updatedAt
     });
   }
 }

--- a/src/common/types/review/review.dto.ts
+++ b/src/common/types/review/review.dto.ts
@@ -1,5 +1,6 @@
 import { IsInt, IsNotEmpty, IsPositive, IsString, IsUUID } from 'class-validator';
 import { Type } from 'class-transformer';
+import { ReviewAllProperties } from './review.types';
 
 export class CreateReviewDTO {
   @IsUUID()
@@ -28,4 +29,10 @@ export class GetReviewsQueryDTO {
   @Type(() => Number)
   @IsInt()
   pageSize: number = 5;
+}
+
+export class GetReviewsResponseDTO {
+  totalCount: number;
+  groupByCount?: { rating: number; count: number }[];
+  list: ReviewAllProperties[];
 }

--- a/src/common/types/review/review.types.ts
+++ b/src/common/types/review/review.types.ts
@@ -25,3 +25,40 @@ export interface ReviewAllProperties {
   createdAt?: Date;
   updatedAt?: Date;
 }
+
+export interface ReviewSelect {
+  id: boolean;
+  createdAt: boolean;
+  rating: boolean;
+  content: boolean;
+  plan?: {
+    select: {
+      tripType: boolean;
+      tripDate: boolean;
+      quotes: {
+        select: {
+          price: boolean;
+          isAssigned: boolean;
+        };
+        where: {
+          isConfirmed: boolean;
+        };
+      };
+    };
+  };
+  owner?: {
+    select: {
+      nickName: boolean;
+      makerProfile: {
+        select: {
+          image: boolean;
+        };
+      };
+    };
+  };
+  writer?: {
+    select: {
+      nickName: boolean;
+    };
+  };
+}

--- a/src/modules/review/review.controller.ts
+++ b/src/modules/review/review.controller.ts
@@ -1,7 +1,7 @@
 import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
 import ReviewService from './review.service';
 import { UserId } from 'src/common/decorators/user.decorator';
-import { CreateReviewDTO, GetReviewsQueryDTO } from 'src/common/types/review/review.dto';
+import { CreateReviewDTO, GetReviewsQueryDTO, GetReviewsResponseDTO } from 'src/common/types/review/review.dto';
 import { ReviewProperties } from 'src/common/types/review/review.types';
 import { Role } from 'src/common/decorators/roleGuard.decorator';
 import { Public } from 'src/common/decorators/public.decorator';
@@ -10,10 +10,21 @@ import { Public } from 'src/common/decorators/public.decorator';
 export default class ReviewController {
   constructor(private readonly service: ReviewService) {}
 
+  @Get('')
+  async getReviewByDreamer(
+    @UserId() dreamerId: string,
+    @Query() options: GetReviewsQueryDTO
+  ): Promise<GetReviewsResponseDTO> {
+    return await this.service.getByDreamer(dreamerId, options);
+  }
+
   @Public()
-  @Get('maker/:makerId')
-  async getReviewByMaker(@Param('makerId') makerId: string, @Query() options: GetReviewsQueryDTO) {
-    return await this.service.getByUser(makerId, options);
+  @Get(':makerId')
+  async getReviewByMaker(
+    @Param('makerId') makerId: string,
+    @Query() options: GetReviewsQueryDTO
+  ): Promise<GetReviewsResponseDTO> {
+    return await this.service.getByMaker(makerId, options);
   }
 
   @Post()

--- a/src/modules/review/review.repository.ts
+++ b/src/modules/review/review.repository.ts
@@ -2,28 +2,39 @@ import { Injectable } from '@nestjs/common';
 import IReview from 'src/common/domains/review/review.interface';
 import ReviewMapper from 'src/common/domains/review/review.mapper';
 import { GetReviewsQueryDTO } from 'src/common/types/review/review.dto';
+import { ReviewSelect } from 'src/common/types/review/review.types';
 import DBClient from 'src/providers/database/prisma/DB.client';
 
 @Injectable()
 export default class ReviewRepository {
   constructor(private readonly db: DBClient) {}
 
-  async getByUser(ownerId: string, options: GetReviewsQueryDTO): Promise<IReview[]> {
+  async getByUser(userId: string, options: GetReviewsQueryDTO, isDreamer: boolean) {
     const { page, pageSize } = options;
 
+    const where = isDreamer ? { writerId: userId } : { ownerId: userId };
+    const select: ReviewSelect = { id: true, createdAt: true, rating: true, content: true };
+
+    if (isDreamer) {
+      select.plan = {
+        select: {
+          tripType: true,
+          tripDate: true,
+          quotes: { select: { price: true, isAssigned: true }, where: { isConfirmed: true } }
+        }
+      };
+      select.owner = { select: { nickName: true, makerProfile: { select: { image: true } } } };
+    } else {
+      select.writer = { select: { nickName: true } };
+    }
+
     const reviews = await this.db.review.findMany({
-      where: { ownerId },
+      where,
       take: pageSize,
       skip: pageSize * (page - 1),
-      select: {
-        id: true,
-        createdAt: true,
-        rating: true,
-        content: true,
-        writer: { select: { nickName: true } }
-      }
+      select
     });
-
+    console.log(reviews);
     return reviews.map((review) => new ReviewMapper(review).toDomain());
   }
 


### PR DESCRIPTION
## 작업한 이슈 번호

- close #108 

## 작업 사항 설명

내가 작성한 리뷰 목록을 조회하는 API를 구현합니다.

## 작업 사항

- [x] 내가 작성한 리뷰 목록 조회 API

## 기타

- 이전에 만든 review repository getByUser 메서드를 통합 사용할 수 있도록 수정했습니다

```
{
  "totalCount": 3,
  "list": [
    {
      "id": "919ddc45-5d2c-4efa-8c5d-5e7f8c6838d2",
      "owner": {
        "nickName": "무궁화",
        "makerProfile": {
          "image": "DEFAULT_1"
        }
      },
      "plan": {
        "tripType": "FOOD_TOUR",
        "tripDate": "2024-11-26T00:00:00.000Z",
        "quotes": [
          {
            "price": 175,
            "isAssigned": false
          }
        ]
      },
      "rating": 4,
      "content": "완벽한 대리 여행이었어요! 덕분에 좋은 경험이었습니다 :)",
      "createdAt": "2025-01-23T12:35:23.970Z"
    }, ...
  ]
}
```