### PR TITLE
비즈니스 로직 내 유저 알림 발송 추가

### DIFF
--- a/src/common/domains/plan/plan.domain.ts
+++ b/src/common/domains/plan/plan.domain.ts
@@ -166,4 +166,8 @@ export default class Plan implements IPlan {
   getStatus(): Status {
     return this.status;
   }
+
+  getTitle(): string {
+    return this.title;
+  }
 }

--- a/src/common/domains/plan/plan.domain.ts
+++ b/src/common/domains/plan/plan.domain.ts
@@ -159,7 +159,6 @@ export default class Plan implements IPlan {
 
   getMakerNickName(makerId: string): string {
     const maker = this.assignees.find((user) => user.getId() === makerId);
-    console.log('maker info:', maker);
 
     return maker.toClient().nickName;
   }

--- a/src/common/domains/plan/plan.domain.ts
+++ b/src/common/domains/plan/plan.domain.ts
@@ -157,6 +157,13 @@ export default class Plan implements IPlan {
     return this.dreamer.toClient().nickName;
   }
 
+  getMakerNickName(makerId: string): string {
+    const maker = this.assignees.find((user) => user.getId() === makerId);
+    console.log('maker info:', maker);
+
+    return maker.toClient().nickName;
+  }
+
   getStatus(): Status {
     return this.status;
   }

--- a/src/common/domains/plan/plan.interface.ts
+++ b/src/common/domains/plan/plan.interface.ts
@@ -15,5 +15,6 @@ export default interface IPlan {
   getDreamerId(): string;
   getStatus(): Status;
   getDreamerNickName(): string;
+  getMakerNickName(id: string): string;
   getConfirmedMakerId(): string;
 }

--- a/src/common/domains/plan/plan.interface.ts
+++ b/src/common/domains/plan/plan.interface.ts
@@ -17,4 +17,5 @@ export default interface IPlan {
   getDreamerNickName(): string;
   getMakerNickName(id: string): string;
   getConfirmedMakerId(): string;
+  getTitle(): string;
 }

--- a/src/common/types/notification/notification.types.ts
+++ b/src/common/types/notification/notification.types.ts
@@ -21,6 +21,8 @@ export interface NotificationEvent {
   CONFIRM_QUOTE: { nickName: string };
   ARRIVE_REQUEST: { nickName: string; tripType: TripType };
   CONFIRM_REQUEST: { nickName: string };
+  REJECT_REQUEST: { nickName: string; planTitle: string };
+  REJECT_QUOTE: { nickName: string; planTitle: string };
   SCHEDULE: { planTitle: string };
 }
 
@@ -29,5 +31,7 @@ export enum NotificationEventName {
   CONFIRM_QUOTE = 'CONFIRM_QUOTE',
   ARRIVE_REQUEST = 'ARRIVE_REQUEST',
   CONFIRM_REQUEST = 'CONFIRM_REQUEST',
+  REJECT_REQUEST = 'REJECT_REQUEST',
+  REJECT_QUOTE = 'REJECT_QUOTE',
   SCHEDULE = 'SCHEDULE'
 }

--- a/src/modules/notification/notification.service.ts
+++ b/src/modules/notification/notification.service.ts
@@ -59,8 +59,10 @@ export default class NotificationService {
     } = {
       ARRIVE_QUOTE: ({ nickName, tripType }) => `${nickName} Maker의 ${tripType} 견적이 도착했어요.`,
       CONFIRM_QUOTE: ({ nickName }) => `${nickName} Maker의 견적이 확정되었어요.`,
+      REJECT_REQUEST: ({ nickName, planTitle }) => `${nickName} Maker가 ${planTitle} 지정견적 요청을 반려했어요.`,
       ARRIVE_REQUEST: ({ nickName, tripType }) => `${nickName} Dreamer가 ${tripType} 지정견적을 요청했어요.`,
       CONFIRM_REQUEST: ({ nickName }) => `${nickName} Dreamer의 견적이 확정되었어요.`,
+      REJECT_QUOTE: ({ nickName, planTitle }) => `${nickName} Dreamer가 ${planTitle} 견적을 반려했어요.`,
       SCHEDULE: ({ planTitle }) => `내일은 ${planTitle} 여행 예정일이에요.`
     };
 

--- a/src/modules/plan/plan.service.ts
+++ b/src/modules/plan/plan.service.ts
@@ -156,6 +156,15 @@ export default class PlanService {
     plan.rejectAssign(data);
     const updatedPlan = await this.planRepository.update(plan);
 
+    const makerNickName = plan.getDreamerNickName();
+    const planTitle = plan.toClient().title;
+    this.eventEmitter.emit('notification', {
+      userId: data.assigneeId,
+      event: NotificationEventName.REJECT_REQUEST,
+      payload: { nickName: makerNickName, planTitle }
+    });
+
+    console.log('견적 취소 완료!');
     return updatedPlan.toClient();
   }
 

--- a/src/modules/plan/plan.service.ts
+++ b/src/modules/plan/plan.service.ts
@@ -114,6 +114,14 @@ export default class PlanService {
     const domainQuote = new QuoteMapper({ ...data, planId, isAssigned, makerId: userId }).toDomain();
     const quote = await this.quoteService.createQuote(domainQuote);
 
+    const makerNickName = quote.maker.nickName;
+    const tripType = plan.toClient().tripType;
+    this.eventEmitter.emit('notification', {
+      userId: plan.getDreamerId(),
+      event: NotificationEventName.ARRIVE_QUOTE,
+      payload: { nickName: makerNickName, tripType }
+    });
+
     return quote;
   }
 

--- a/src/modules/plan/plan.service.ts
+++ b/src/modules/plan/plan.service.ts
@@ -165,7 +165,7 @@ export default class PlanService {
     const updatedPlan = await this.planRepository.update(plan);
 
     const makerNickName = plan.getMakerNickName(data.assigneeId);
-    const planTitle = plan.toClient().title;
+    const planTitle = plan.getTitle();
     this.eventEmitter.emit('notification', {
       userId: data.assigneeId,
       event: NotificationEventName.REJECT_REQUEST,
@@ -243,7 +243,7 @@ export default class PlanService {
     await Promise.all([...deletedQuotes, deletedPlan]);
 
     const dreamerNickName = plan.getDreamerNickName();
-    const planTitle = plan.toClient().title;
+    const planTitle = plan.getTitle();
     quotes.map((quote) =>
       this.eventEmitter.emit('notification', {
         userId: quote.getMakerId(),


### PR DESCRIPTION
## 작업한 이슈 번호

- close #122 

## 작업 사항 설명

플랜 취소로 인한 Maker에 견적 취소 알림과
지정견적 요청 반려로 인한 Dreamer에 견적 취소 알림,
견적 생성시 Dreamer에 견적 도착 알림을 추가합니다.

## 작업 사항

- [x] eventType 및 알림 메시지 추가
- [x] 플랜 취소로 인한 Maker에 견적 취소 알림
- [x] 지정견적 요청 반려로 인한 Dreamer에 견적 취소 알림
- [x] 견적 생성시 Dreamer에 견적 도착 알림

## 기타

- 가능하면 plan에서 모두 알림을 추가하려고 했는데, 견적 확정시 plan 상태 업데이트 코드를 찾지 못해서 견적 확정 알림은 다음 PR에 올리겠습니다!
- 스케줄러를 이용한 여행일 알림도 다음 PR에 올리겠습니다.
