### PR TITLE
견적서 단일조회 api 오류 해결

### DIFF
--- a/src/common/types/quote/quote.type.ts
+++ b/src/common/types/quote/quote.type.ts
@@ -1,4 +1,5 @@
 import { StatusEnum } from 'src/common/constants/status.type';
+import { PlanReference } from '../plan/plan.type';
 
 export type QuoteWhereConditions = {
   isDeletedAt: Date | null;

--- a/src/common/types/quote/quoteProperties.ts
+++ b/src/common/types/quote/quoteProperties.ts
@@ -1,8 +1,5 @@
 import { IUser } from 'src/common/domains/user/user.interface';
 import { FilteredUserProperties, UserProperties } from '../user/user.types';
-import { TripType } from 'src/common/constants/tripType.type';
-import { ServiceArea } from 'src/common/constants/serviceArea.type';
-import { Status } from 'src/common/constants/status.type';
 import { PlanReference } from '../plan/plan.type';
 
 export interface QuoteProperties {

--- a/src/modules/quote/quote.repository.ts
+++ b/src/modules/quote/quote.repository.ts
@@ -38,7 +38,19 @@ export default class QuoteRepository {
     const quote = await this.db.quote.findUnique({
       where: { id, isDeletedAt: null },
       include: {
-        plan: true,
+        plan: {
+          select: {
+            id: true,
+            createdAt: true,
+            title: true,
+            tripDate: true,
+            tripType: true,
+            serviceArea: true,
+            details: true,
+            status: true,
+            dreamer: { select: { id: true, nickName: true } }
+          }
+        },
         maker: true
       }
     });


### PR DESCRIPTION
## 작업한 이슈 번호

- close #127

## 작업 사항 설명
Quote 도메인 안에서 PlanReference를 가지게 되면서 잘못 수정하면서 생긴 오류 해결


## 작업 사항

- [x] 견적서 단일조회 api 오류 해결

## 기타
- Quote 단일 조회(Maker) `GET` /quotes/:quoteId
    - REQUEST
        
        ```jsx
        GET /quotes/:quoteId
        
        GET http://localhost:4000/quotes/b9063bfc-6282-4435-b512-944a4ffd19ac
        Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiIwMzJkN2JkNC0xMTZjLTQ2N2ItOTM1Mi1hMTRiMGQ0OTRlZjkiLCJyb2xlIjoiTUFLRVIiLCJpYXQiOjE3Mzc4OTk2NTYsImV4cCI6MTczNzk4NjA1Nn0.NCd3kpAb84ktM8c2nApmD6StsoljqGCH04WgF5BvqeM
        ```
        
    - RESPONSE
        
        
        ```jsx
        HTTP/1.1 200 OK
        X-Powered-By: Express
        Vary: Origin
        Access-Control-Allow-Credentials: true
        Content-Type: application/json; charset=utf-8
        Content-Length: 644
        ETag: W/"284-/lAoh97mpn0H9dh25+VJ4NkcCdw"
        Date: Sun, 26 Jan 2025 14:47:19 GMT
        Connection: close
        
        {
          "id": "b9063bfc-6282-4435-b512-944a4ffd19ac",
          "createdAt": "2024-11-13T00:00:00.000Z",
          "updatedAt": "2025-01-26T11:42:52.058Z",
          "price": 180,
          "content": "서울 플랜21 견적",
          "plan": {
            "id": "c1d848c2-2ee2-49c6-aad7-ed6933497d42",
            "createdAt": "2024-05-25T00:00:00.000Z",
            "title": "플랜21타이틀",
            "tripDate": "2024-11-25T00:00:00.000Z",
            "tripType": "ACTIVITY",
            "serviceArea": "SEOUL",
            "details": "플랜21디테일",
            "status": "COMPLETED",
            "dreamer": {
              "id": "66885a3c-50f4-427b-8a92-3702c6976fb0",
              "nickName": "호랑이"
            }
          },
          "maker": {
            "id": "032d7bd4-116c-467b-9352-a14b0d494ef9",
            "role": "MAKER",
            "nickName": "장미",
            "coconut": 1000
          },
          "isConfirmed": true,
          "isAssigned": false
        }
        ```
        
       
        
    - 파라미터
        
        Params
        
        - quoteId: string 필수
    - 참고상황
        - Dreamer의 리스폰스 구조는 Maker의 userStats를 포함해서 줄 예정
    - 에러상황
        - 해당 플랜의 Dreamer거나 해당 견적의 Maker가 아닌 경우 403 에러
        - 없는 견적의 id를 입력할 경우 404 에러
