### PR TITLE
유저 프로필카드 데이터 불러오는 메서드 생성

### DIFF
--- a/src/common/domains/follow/follow.domain.ts
+++ b/src/common/domains/follow/follow.domain.ts
@@ -1,22 +1,17 @@
-import { UserReference } from 'src/common/types/user/user.types';
-import { FollowProperties, FollowPropertiesWithMaker } from '../../types/follow/follow.types';
+import { FollowProperties } from '../../types/follow/follow.types';
 import IFollow from './follow.interface';
 
 export default class Follow implements IFollow {
   private readonly id?: string;
   private readonly makerId: string;
-  private readonly maker?: UserReference;
   private readonly dreamerId: string;
-  private readonly isFollowed?: boolean;
   private readonly createdAt?: Date;
   private readonly updatedAt?: Date;
 
-  constructor(follow: FollowPropertiesWithMaker) {
+  constructor(follow: FollowProperties) {
     this.id = follow?.id;
     this.makerId = follow.makerId;
-    this.maker = follow?.maker;
     this.dreamerId = follow.dreamerId;
-    this.isFollowed = follow?.isFollowed;
     this.createdAt = follow?.createdAt;
     this.updatedAt = follow?.updatedAt;
   }
@@ -29,31 +24,15 @@ export default class Follow implements IFollow {
     return this.makerId;
   }
 
-  getMaker(): UserReference {
-    return this.maker;
-  }
-
   getId(): string {
     return this.id;
   }
 
-  toDB() {
+  toObject() {
     return {
       id: this.id,
       makerId: this.makerId,
       dreamerId: this.dreamerId,
-      createdAt: this.createdAt,
-      updatedAt: this.updatedAt
-    };
-  }
-
-  toClient() {
-    return {
-      id: this.id,
-      makerId: this.makerId,
-      maker: this.maker,
-      dreamerId: this.dreamerId,
-      isFollowed: this.isFollowed,
       createdAt: this.createdAt,
       updatedAt: this.updatedAt
     };

--- a/src/common/domains/follow/follow.interface.ts
+++ b/src/common/domains/follow/follow.interface.ts
@@ -1,10 +1,7 @@
-import { UserReference } from 'src/common/types/user/user.types';
-import { FollowProperties, FollowPropertiesWithMaker } from '../../types/follow/follow.types';
+import { FollowProperties } from '../../types/follow/follow.types';
 
 export default interface IFollow {
   getMakerId(): string;
-  getMaker(): UserReference;
   getId(): string;
-  toDB(): FollowProperties;
-  toClient(): FollowPropertiesWithMaker;
+  toObject(): FollowProperties;
 }

--- a/src/common/domains/follow/follow.mapper.ts
+++ b/src/common/domains/follow/follow.mapper.ts
@@ -1,24 +1,15 @@
-import { FollowPropertiesFromDB } from '../../types/follow/follow.types';
+import { FollowProperties } from '../../types/follow/follow.types';
 import Follow from './follow.domain';
 
 export default class FollowMapper {
-  constructor(private readonly follow: FollowPropertiesFromDB) {}
+  constructor(private readonly follow: FollowProperties) {}
 
   toDomain() {
     if (!this.follow) return null;
 
-    const isFollowed = this.follow.maker?.followers.length > 0 ? true : false;
-
     return new Follow({
       id: this.follow.id,
       makerId: this.follow.makerId,
-      maker: {
-        nickName: this.follow.maker?.nickName,
-        image: this.follow.maker?.makerProfile.image,
-        gallery: this.follow.maker?.makerProfile.gallery,
-        serviceTypes: this.follow.maker?.makerProfile.serviceTypes
-      },
-      isFollowed,
       dreamerId: this.follow.dreamerId,
       createdAt: this.follow.createdAt,
       updatedAt: this.follow.updatedAt

--- a/src/common/domains/user/user.domain.ts
+++ b/src/common/domains/user/user.domain.ts
@@ -1,10 +1,17 @@
 import { Role } from 'src/common/constants/role.type';
-import { FilteredUserProperties, PasswordProperties, UserProperties } from '../../types/user/user.types';
+import {
+  FilteredUserProperties,
+  PasswordProperties,
+  UserProperties,
+  UserPropertiesFromDB,
+  UserReference
+} from '../../types/user/user.types';
 import { ComparePassword, HashingPassword } from '../../utilities/hashingPassword';
 import { IUser } from './user.interface';
 import BadRequestError from 'src/common/errors/badRequestError';
 import ErrorMessage from 'src/common/constants/errorMessage.enum';
 import UnauthorizedError from 'src/common/errors/unauthorizedError';
+import { MakerProfileProperties } from 'src/common/types/user/profile.types';
 
 export default class User implements IUser {
   private readonly id?: string;
@@ -14,10 +21,12 @@ export default class User implements IUser {
   private password: string;
   private phoneNumber: string;
   private coconut: number;
+  private readonly followees: UserReference[];
+  private readonly makerProfile: Partial<MakerProfileProperties>;
   private readonly createdAt?: Date;
   private readonly updatedAt?: Date;
 
-  constructor(user: UserProperties) {
+  constructor(user: UserPropertiesFromDB) {
     this.id = user?.id;
     this.role = user.role;
     this.nickName = user.nickName;
@@ -25,6 +34,8 @@ export default class User implements IUser {
     this.password = user.password;
     this.phoneNumber = user.phoneNumber;
     this.coconut = user.coconut;
+    this.followees = user?.followees;
+    this.makerProfile = user?.makerProfile;
     this.createdAt = user?.createdAt;
     this.updatedAt = user?.updatedAt;
   }
@@ -106,5 +117,9 @@ export default class User implements IUser {
 
   getRole(): Role {
     return this.role;
+  }
+
+  isFollowed(dreamerId: string): boolean {
+    return this.followees.some((dreamer) => dreamer.id === dreamerId);
   }
 }

--- a/src/common/domains/user/user.interface.ts
+++ b/src/common/domains/user/user.interface.ts
@@ -10,4 +10,5 @@ export interface IUser {
   toClientAll(): Omit<UserProperties, 'password'>;
   getId(): string;
   getRole(): Role;
+  isFollowed(dreamerId: string): boolean;
 }

--- a/src/common/domains/user/user.mapper.ts
+++ b/src/common/domains/user/user.mapper.ts
@@ -1,8 +1,8 @@
-import { UserProperties } from '../../types/user/user.types';
+import { UserPropertiesFromDB } from '../../types/user/user.types';
 import User from './user.domain';
 
 export default class UserMapper {
-  constructor(private readonly user: UserProperties) {}
+  constructor(private readonly user: UserPropertiesFromDB) {}
 
   toDomain() {
     if (!this.user) return null;
@@ -15,6 +15,8 @@ export default class UserMapper {
       password: this.user.password,
       phoneNumber: this.user.phoneNumber,
       coconut: this.user.coconut,
+      followees: this.user?.followees,
+      makerProfile: this.user?.makerProfile,
       createdAt: this.user.createdAt,
       updatedAt: this.user.updatedAt
     });

--- a/src/common/types/follow/follow.types.ts
+++ b/src/common/types/follow/follow.types.ts
@@ -33,12 +33,3 @@ export interface FollowPropertiesFromDB {
   createdAt?: Date;
   updatedAt?: Date;
 }
-
-export interface FollowPropertiesToClient extends FollowPropertiesWithMaker {
-  userStats: {
-    averageRating: number;
-    totalReviews: number;
-    totalFollows: number;
-    totalConfirms: number;
-  };
-}

--- a/src/common/types/follow/follow.types.ts
+++ b/src/common/types/follow/follow.types.ts
@@ -1,34 +1,6 @@
-import { ProfileImage } from 'src/common/constants/image.type';
-import { TripType } from 'src/common/constants/tripType.type';
-import { UserReference } from '../user/user.types';
-
 export interface FollowProperties {
   id?: string;
   makerId: string;
-  dreamerId: string;
-  createdAt?: Date;
-  updatedAt?: Date;
-}
-
-export interface FollowPropertiesWithMaker {
-  id?: string;
-  makerId: string;
-  maker?: UserReference;
-  dreamerId: string;
-  isFollowed?: boolean;
-  createdAt?: Date;
-  updatedAt?: Date;
-}
-
-export interface FollowPropertiesFromDB {
-  id?: string;
-  makerId: string;
-  maker?: {
-    nickName: string;
-    makerProfile: { image: ProfileImage; gallery: string; serviceTypes: TripType[] };
-    followers?: { id: string }[];
-    followees?: { id: string }[];
-  };
   dreamerId: string;
   createdAt?: Date;
   updatedAt?: Date;

--- a/src/common/types/user/query.dto.ts
+++ b/src/common/types/user/query.dto.ts
@@ -1,7 +1,7 @@
 import { Type } from 'class-transformer';
 import { IsInt } from 'class-validator';
 
-export class GetFollowQueryDTO {
+export class PaginationQueryDTO {
   @Type(() => Number)
   @IsInt()
   page: number = 1;

--- a/src/common/types/user/user.response.dto.ts
+++ b/src/common/types/user/user.response.dto.ts
@@ -2,7 +2,6 @@ import { ProfileImage, ProfileImageEnum } from 'src/common/constants/image.type'
 import { RoleEnum } from 'src/common/constants/role.type';
 import { ServiceAreaEnum } from 'src/common/constants/serviceArea.type';
 import { TripType, TripTypeEnum } from 'src/common/constants/tripType.type';
-import { UserReference } from './user.types';
 
 export class UserResponseDTO {
   id?: string;

--- a/src/common/types/user/user.response.dto.ts
+++ b/src/common/types/user/user.response.dto.ts
@@ -1,7 +1,8 @@
-import { ProfileImageEnum } from 'src/common/constants/image.type';
+import { ProfileImage, ProfileImageEnum } from 'src/common/constants/image.type';
 import { RoleEnum } from 'src/common/constants/role.type';
 import { ServiceAreaEnum } from 'src/common/constants/serviceArea.type';
-import { TripTypeEnum } from 'src/common/constants/tripType.type';
+import { TripType, TripTypeEnum } from 'src/common/constants/tripType.type';
+import { UserReference } from './user.types';
 
 export class UserResponseDTO {
   id?: string;
@@ -38,4 +39,22 @@ export class MakerProfileResponseDTO {
   detailDescription: string;
   createdAt?: Date;
   updatedAt?: Date;
+}
+
+export class ProfileCardResponseDTO {
+  id?: string;
+  makerId?: string;
+  maker?: {
+    nickName?: string;
+    image?: ProfileImage;
+    gallery?: string;
+    serviceTypes?: TripType[];
+    averageRating: number;
+    totalReviews: number;
+    totalFollows: number;
+    totalConfirms: number;
+  };
+  dreamerId?: string;
+  isFollowed?: boolean;
+  createdAt?: Date;
 }

--- a/src/common/types/user/user.types.ts
+++ b/src/common/types/user/user.types.ts
@@ -1,6 +1,7 @@
 import { ProfileImage } from 'src/common/constants/image.type';
 import { Role } from 'src/common/constants/role.type';
 import { TripType } from 'src/common/constants/tripType.type';
+import { MakerProfileProperties } from './profile.types';
 
 export interface UserProperties {
   id?: string;
@@ -10,6 +11,20 @@ export interface UserProperties {
   password: string;
   phoneNumber: string;
   coconut: number;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+export interface UserPropertiesFromDB {
+  id?: string;
+  role: Role;
+  nickName: string;
+  email: string;
+  password: string;
+  phoneNumber: string;
+  coconut: number;
+  followees?: UserReference[];
+  makerProfile?: Partial<MakerProfileProperties>;
   createdAt?: Date;
   updatedAt?: Date;
 }
@@ -27,7 +42,8 @@ export interface PasswordProperties {
 }
 
 export interface UserReference {
-  nickName: string;
+  id?: string;
+  nickName?: string;
   image?: ProfileImage;
   gallery?: string;
   serviceTypes?: TripType[];

--- a/src/modules/follow/follow.controller.ts
+++ b/src/modules/follow/follow.controller.ts
@@ -1,23 +1,12 @@
-import { Body, Controller, Delete, Get, HttpCode, HttpStatus, Post, Query } from '@nestjs/common';
+import { Body, Controller, Delete, HttpCode, HttpStatus, Post } from '@nestjs/common';
 import FollowService from './follow.service';
 import { UserId } from 'src/common/decorators/user.decorator';
 import { Role } from 'src/common/decorators/roleGuard.decorator';
-import { GetFollowQueryDTO } from 'src/common/types/follow/follow.dto';
-import { FollowProperties } from 'src/common/types/follow/follow.types';
 
 @Controller('follow')
 @Role('DREAMER')
 export default class FollowController {
   constructor(private readonly service: FollowService) {}
-
-  @Get()
-  async getFollowList(
-    @UserId() userId: string,
-    @Query() options: GetFollowQueryDTO
-  ): Promise<{ totalCount: number; list: FollowProperties[] }> {
-    return await this.service.get(userId, options);
-  }
-
   @Post()
   @HttpCode(HttpStatus.NO_CONTENT)
   async follow(@UserId() dreamerId: string, @Body('makerId') makerId: string): Promise<null> {

--- a/src/modules/follow/follow.module.ts
+++ b/src/modules/follow/follow.module.ts
@@ -1,21 +1,17 @@
 import { Module } from '@nestjs/common';
-import PrismaModule from 'src/providers/database/prisma/prisma.module';
 import FollowRepository from './follow.repository';
 import FollowController from './follow.controller';
 import FollowService from './follow.service';
-import UserStatsModule from '../userStats/userStats.module';
 import { BullModule } from '@nestjs/bullmq';
 
 @Module({
   imports: [
     BullModule.registerQueue({
       name: 'stats'
-    }),
-    PrismaModule,
-    UserStatsModule
+    })
   ],
   controllers: [FollowController],
   providers: [FollowService, FollowRepository],
-  exports: []
+  exports: [FollowService]
 })
 export default class FollowModule {}

--- a/src/modules/follow/follow.repository.ts
+++ b/src/modules/follow/follow.repository.ts
@@ -1,36 +1,20 @@
 import { Injectable } from '@nestjs/common';
 import DBClient from 'src/providers/database/prisma/DB.client';
 import FollowMapper from '../../common/domains/follow/follow.mapper';
-import { FollowProperties } from '../../common/types/follow/follow.types';
 import IFollow from '../../common/domains/follow/follow.interface';
-import { GetFollowQueryDTO } from 'src/common/types/follow/follow.dto';
+import { PaginationQueryDTO } from 'src/common/types/user/query.dto';
 
 @Injectable()
 export default class FollowRepository {
   constructor(private readonly db: DBClient) {}
 
-  async get(dreamerId: string, options: GetFollowQueryDTO) {
+  async get(dreamerId: string, options: PaginationQueryDTO): Promise<IFollow[]> {
     const { page, pageSize } = options;
 
     const data = await this.db.follow.findMany({
       where: { dreamerId },
       take: pageSize,
-      skip: pageSize * (page - 1),
-      select: {
-        id: true,
-        makerId: true,
-        dreamerId: true,
-        maker: {
-          select: {
-            nickName: true,
-            makerProfile: { select: { image: true, gallery: true, serviceTypes: true } },
-            followers: {
-              where: { dreamerId },
-              select: { id: true }
-            }
-          }
-        }
-      }
+      skip: pageSize * (page - 1)
     });
     return data.map((follow) => new FollowMapper(follow).toDomain());
   }

--- a/src/modules/follow/follow.repository.ts
+++ b/src/modules/follow/follow.repository.ts
@@ -34,7 +34,7 @@ export default class FollowRepository {
   }
 
   async create(data: IFollow): Promise<null> {
-    await this.db.follow.create({ data: data.toDB() });
+    await this.db.follow.create({ data: data.toObject() });
     return;
   }
 

--- a/src/modules/follow/follow.service.ts
+++ b/src/modules/follow/follow.service.ts
@@ -23,9 +23,7 @@ export default class FollowService {
     const follows = await this.repository.get(userId, options);
     const totalCount = await this.repository.count(userId);
 
-    const followData = follows.map((follow) => {
-      return follow.toObject();
-    });
+    const followData = follows.map((follow) => follow.toObject());
 
     return { totalCount, followData };
   }

--- a/src/modules/follow/follow.service.ts
+++ b/src/modules/follow/follow.service.ts
@@ -24,7 +24,7 @@ export default class FollowService {
     const totalCount = await this.repository.count(userId);
 
     const followData = follows.map((follow) => {
-      return follow.toClient();
+      return follow.toObject();
     });
 
     return { totalCount, followData };

--- a/src/modules/follow/follow.service.ts
+++ b/src/modules/follow/follow.service.ts
@@ -3,36 +3,31 @@ import FollowRepository from './follow.repository';
 import BadRequestError from 'src/common/errors/badRequestError';
 import ErrorMessage from 'src/common/constants/errorMessage.enum';
 import Follow from '../../common/domains/follow/follow.domain';
-import UserStatsService from '../userStats/userStats.service';
-import { GetFollowQueryDTO } from 'src/common/types/follow/follow.dto';
 import { FollowProperties } from 'src/common/types/follow/follow.types';
 import { Queue } from 'bullmq';
 import { InjectQueue } from '@nestjs/bullmq';
 import { EventType } from 'src/common/constants/event.type';
+import { PaginationQueryDTO } from 'src/common/types/user/query.dto';
 
 @Injectable()
 export default class FollowService {
   constructor(
     @InjectQueue('stats') private readonly queue: Queue,
-    private readonly repository: FollowRepository,
-    private readonly userStats: UserStatsService
+    private readonly repository: FollowRepository
   ) {}
 
-  async get(userId: string, options: GetFollowQueryDTO): Promise<{ totalCount: number; list: FollowProperties[] }> {
+  async get(
+    userId: string,
+    options: PaginationQueryDTO
+  ): Promise<{ totalCount: number; followData: FollowProperties[] }> {
     const follows = await this.repository.get(userId, options);
-
-    const list = await Promise.all(
-      follows.map(async (follow) => {
-        const makerStats = await this.userStats.get(follow.getMakerId());
-        const followData = follow.toClient();
-
-        return { ...followData, maker: { ...followData.maker, ...makerStats } };
-      })
-    );
-
     const totalCount = await this.repository.count(userId);
 
-    return { totalCount, list };
+    const followData = follows.map((follow) => {
+      return follow.toClient();
+    });
+
+    return { totalCount, followData };
   }
 
   // 찜 기능: Dreamer -> Maker

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -75,10 +75,6 @@ export default class UserController {
   @ApiOkResponse({ type: UserResponseDTO })
   @ApiUnauthorizedResponse({ description: 'Access Token이 없거나 만료되었습니다' })
   async getUser(@UserId() userId: string): Promise<Omit<UserProperties, 'password'>> {
-    // TEST
-    const u = await this.service.getProfileCardData(userId);
-    console.log(u);
-
     return await this.service.getUser(userId);
   }
 

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, HttpCode, HttpStatus, Patch, Post, Res } from '@nestjs/common';
+import { Body, Controller, Get, HttpCode, HttpStatus, Patch, Post, Query, Res } from '@nestjs/common';
 import UserService from './user.service';
 import { Cookies } from 'src/common/decorators/cookie.decorator';
 import { Public } from 'src/common/decorators/public.decorator';
@@ -30,8 +30,10 @@ import UpdateUserDTO from '../../common/types/user/updateUser.dto';
 import UnauthorizedError from 'src/common/errors/unauthorizedError';
 import ErrorMessage from 'src/common/constants/errorMessage.enum';
 import { UserRole } from 'src/common/decorators/role.decorator';
+import { Role } from 'src/common/decorators/roleGuard.decorator';
+import { PaginationQueryDTO } from 'src/common/types/user/query.dto';
 
-@Controller('user')
+@Controller('users')
 export default class UserController {
   constructor(private readonly service: UserService) {}
 
@@ -73,6 +75,10 @@ export default class UserController {
   @ApiOkResponse({ type: UserResponseDTO })
   @ApiUnauthorizedResponse({ description: 'Access Token이 없거나 만료되었습니다' })
   async getUser(@UserId() userId: string): Promise<Omit<UserProperties, 'password'>> {
+    // TEST
+    const u = await this.service.getProfileCardData(userId);
+    console.log(u);
+
     return await this.service.getUser(userId);
   }
 
@@ -86,6 +92,12 @@ export default class UserController {
     @UserId() userId: string
   ): Promise<MakerProfileProperties | DreamerProfileProperties> {
     return await this.service.getProfile(role, userId);
+  }
+
+  @Get('following')
+  @Role('DREAMER')
+  async getFollowList(@UserId() userId: string, @Query() options: PaginationQueryDTO) {
+    return await this.service.getFollows(userId, options);
   }
 
   @Patch('update')

--- a/src/modules/user/user.module.ts
+++ b/src/modules/user/user.module.ts
@@ -5,13 +5,17 @@ import UserRepository from './user.repository';
 import { PassportModule } from '@nestjs/passport';
 import { JwtModule } from '@nestjs/jwt';
 import { JwtStrategy } from './jwt/jwt.strategy';
+import UserStatsModule from '../userStats/userStats.module';
+import FollowModule from '../follow/follow.module';
 
 @Module({
   imports: [
     PassportModule,
     JwtModule.register({
       secret: process.env.JWT_SECRET
-    })
+    }),
+    UserStatsModule,
+    FollowModule
   ],
   controllers: [UserController],
   providers: [UserService, UserRepository, JwtStrategy],

--- a/src/modules/user/user.repository.ts
+++ b/src/modules/user/user.repository.ts
@@ -18,9 +18,7 @@ export default class UserRepository {
       }
     });
 
-    if (data) {
-      return new UserMapper(data).toDomain();
-    }
+    return new UserMapper(data).toDomain();
   }
 
   async findByNickName(nickName: string): Promise<IUser> {
@@ -30,21 +28,33 @@ export default class UserRepository {
       }
     });
 
-    if (data) {
-      return new UserMapper(data).toDomain();
-    }
+    return new UserMapper(data).toDomain();
   }
 
   async findById(id: string): Promise<IUser> {
     const data = await this.db.user.findUnique({
-      where: {
-        id
+      where: { id }
+    });
+
+    return new UserMapper(data).toDomain();
+  }
+
+  async findByIdWithProfileAndFollow(id: string) {
+    const user = await this.db.user.findUnique({
+      where: { id },
+      select: {
+        role: true,
+        email: true,
+        password: true,
+        phoneNumber: true,
+        coconut: true,
+        nickName: true,
+        makerProfile: { select: { image: true, gallery: true, serviceTypes: true } },
+        followees: { select: { id: true } }
       }
     });
 
-    if (data) {
-      return new UserMapper(data).toDomain();
-    }
+    return new UserMapper(user).toDomain();
   }
 
   async create(user: Partial<UserProperties>): Promise<IUser> {

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -7,12 +7,19 @@ import { JwtService } from '@nestjs/jwt';
 import { DreamerProfile, MakerProfile } from '../../common/domains/user/profile.domain';
 import { FilteredUserProperties, PasswordProperties, UserProperties } from '../../common/types/user/user.types';
 import { DreamerProfileProperties, MakerProfileProperties } from '../../common/types/user/profile.types';
+import UserStatsService from '../userStats/userStats.service';
+import { RoleEnum } from 'src/common/constants/role.type';
+import FollowService from '../follow/follow.service';
+import { PaginationQueryDTO } from 'src/common/types/user/query.dto';
+import { ProfileCardResponseDTO } from 'src/common/types/user/user.response.dto';
 
 @Injectable()
 export default class UserService {
   constructor(
     private readonly repository: UserRepository,
-    private readonly jwt: JwtService
+    private readonly jwt: JwtService,
+    private readonly userStats: UserStatsService,
+    private readonly follow: FollowService
   ) {}
 
   async createUser(data): Promise<null> {
@@ -135,4 +142,51 @@ export default class UserService {
 
     return !user;
   }
+
+  async getProfileCardData(userId: string) {
+    const user = await this.repository.findById(userId);
+    const userData = user.get();
+    const profile = (await this.getProfile(RoleEnum.MAKER, userId)) as MakerProfileProperties;
+    const stats = await this.userStats.get(userId);
+
+    return {
+      nickName: userData.nickName,
+      image: profile.image,
+      gallery: profile.gallery,
+      serviceTypes: profile.serviceTypes,
+      ...stats
+    };
+  }
+
+  async getFollows(
+    userId: string,
+    options: PaginationQueryDTO
+  ): Promise<{ totalCount: number; list: ProfileCardResponseDTO[] }> {
+    const { totalCount, followData } = await this.follow.get(userId, options);
+    const list = await Promise.all(
+      followData.map(async (follow) => {
+        const profile = await this.getProfileCardData(follow.makerId);
+        return { ...follow, maker: { ...profile } };
+      })
+    );
+
+    return { totalCount, list };
+  }
 }
+
+// async get(userId: string, options: GetFollowQueryDTO): Promise<{ totalCount: number; list: FollowProperties[] }> {
+// 	const follows = await this.repository.get(userId, options);
+
+// 	const list = await Promise.all(
+// 		follows.map(async (follow) => {
+// 			const makerStats = await this.userStats.get(follow.getMakerId());
+// 			const followData = follow.toClient();
+
+// 			return { ...followData, maker: { ...followData.maker, ...makerStats } };
+// 		})
+// 	);
+
+// 	const totalCount = await this.repository.count(userId);
+
+// 	return { totalCount, list };
+// }

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -173,20 +173,3 @@ export default class UserService {
     return { totalCount, list };
   }
 }
-
-// async get(userId: string, options: GetFollowQueryDTO): Promise<{ totalCount: number; list: FollowProperties[] }> {
-// 	const follows = await this.repository.get(userId, options);
-
-// 	const list = await Promise.all(
-// 		follows.map(async (follow) => {
-// 			const makerStats = await this.userStats.get(follow.getMakerId());
-// 			const followData = follow.toClient();
-
-// 			return { ...followData, maker: { ...followData.maker, ...makerStats } };
-// 		})
-// 	);
-
-// 	const totalCount = await this.repository.count(userId);
-
-// 	return { totalCount, list };
-// }


### PR DESCRIPTION
## 작업한 이슈 번호

- close #126 

## 작업 사항 설명

유저 프로필카드에 들어가는 데이터를 공통적으로 조회하는 메서드를 생성합니다.

## 작업 사항

- [x] 유저 프로필카드 데이터 조회 메서드
- [x] get follows 메서드에 적용

## 기타

- user 라우트를 /users로 변경
- get follows: [GET] /users/following

```
{
  "totalCount": 3,
  "list": [
    {
      "id": "298d6acb-b2dd-445e-be53-34bc6e7db569",
      "makerId": "ef846519-2b73-4be4-807e-f6ef1c07eb60",
      "dreamerId": "66885a3c-50f4-427b-8a92-3702c6976fb0",
      "createdAt": "2025-01-25T13:49:42.825Z",
      "updatedAt": "2025-01-25T13:49:42.825Z",
      "maker": {
        "nickName": "아카시아",
        "image": "DEFAULT_3",
        "gallery": "https://www.instagram.com/codeit_kr/",
        "serviceTypes": [
          "RELAXATION",
          "SHOPPING"
        ],
        "averageRating": 5,
        "totalReviews": 3,
        "totalFollows": 4,
        "totalConfirms": 3
      }
    }, ...
  ]
}
```