### PR TITLE
메이커 ID를 통한 프로필 조회 API 생성

### DIFF
--- a/src/common/decorators/user.decorator.ts
+++ b/src/common/decorators/user.decorator.ts
@@ -3,5 +3,5 @@ import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 export const UserId = createParamDecorator((data: unknown, ctx: ExecutionContext) => {
   const request = ctx.switchToHttp().getRequest();
 
-  return request.user.userId;
+  return request.user?.userId;
 });

--- a/src/common/domains/user/user.domain.ts
+++ b/src/common/domains/user/user.domain.ts
@@ -10,7 +10,7 @@ import { ComparePassword, HashingPassword } from '../../utilities/hashingPasswor
 import { IUser } from './user.interface';
 import BadRequestError from 'src/common/errors/badRequestError';
 import ErrorMessage from 'src/common/constants/errorMessage.enum';
-import { MakerProfileProperties } from 'src/common/types/user/profile.types';
+import { MakerInfoAndProfileProperties, MakerProfileProperties } from 'src/common/types/user/profile.types';
 
 export default class User implements IUser {
   private readonly id?: string;
@@ -120,5 +120,25 @@ export default class User implements IUser {
 
   isFollowed(dreamerId: string): boolean {
     return this.followers?.some((follower) => follower.dreamerId === dreamerId);
+  }
+
+  getWithMakerProfile(withDetails?: boolean): Partial<MakerInfoAndProfileProperties> {
+    const profile = {
+      id: this.id,
+      nickName: this.nickName,
+      image: this.makerProfile.image,
+      gallery: this.makerProfile.gallery,
+      serviceTypes: this.makerProfile.serviceTypes
+    };
+
+    if (withDetails) {
+      return {
+        ...profile,
+        serviceArea: this.makerProfile.serviceArea,
+        description: this.makerProfile.description,
+        detailDescription: this.makerProfile.detailDescription
+      };
+    }
+    return profile;
   }
 }

--- a/src/common/domains/user/user.interface.ts
+++ b/src/common/domains/user/user.interface.ts
@@ -1,4 +1,5 @@
 import { Role } from 'src/common/constants/role.type';
+import { MakerInfoAndProfileProperties } from 'src/common/types/user/profile.types';
 import { FilteredUserProperties, PasswordProperties, UserProperties } from 'src/common/types/user/user.types';
 
 export interface IUser {
@@ -11,4 +12,5 @@ export interface IUser {
   getId(): string;
   getRole(): Role;
   isFollowed(dreamerId: string): boolean;
+  getWithMakerProfile(withDetails?: boolean): Partial<MakerInfoAndProfileProperties>;
 }

--- a/src/common/guards/user.guard.ts
+++ b/src/common/guards/user.guard.ts
@@ -22,16 +22,12 @@ export class UserGuard extends AuthGuard('jwt') {
 
     // @Public() 데코레이터가 있어도 jwt 토큰 있을 경우 검증 실행 후 통과
     const request = context.switchToHttp().getRequest();
-    console.log('request');
     const authHeader = request.headers?.authorization?.startsWith('Bearer ');
-    console.log(authHeader);
     if (isPublic) {
-      console.log('isPublic');
       if (authHeader) {
         const canActivate = await super.canActivate(context);
         if (!canActivate) return false; // 토큰이 있지만 만료된 경우
       }
-      console.log('go true!');
       return true;
     }
 

--- a/src/common/guards/user.guard.ts
+++ b/src/common/guards/user.guard.ts
@@ -14,12 +14,26 @@ export class UserGuard extends AuthGuard('jwt') {
   }
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    // 비로그인 상태로 요청 가능한 API: @Public() 데코레이터 있을 경우 통과
+    // 비로그인 상태로 요청 가능한 API: @Public() 데코레이터 있을 경우
     const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
       context.getHandler(),
       context.getClass()
     ]);
-    if (isPublic) return true;
+
+    // @Public() 데코레이터가 있어도 jwt 토큰 있을 경우 검증 실행 후 통과
+    const request = context.switchToHttp().getRequest();
+    console.log('request');
+    const authHeader = request.headers?.authorization?.startsWith('Bearer ');
+    console.log(authHeader);
+    if (isPublic) {
+      console.log('isPublic');
+      if (authHeader) {
+        const canActivate = await super.canActivate(context);
+        if (!canActivate) return false; // 토큰이 있지만 만료된 경우
+      }
+      console.log('go true!');
+      return true;
+    }
 
     // canActive를 통해 jwt 토큰 검증 후 context에 payload 정보 설정
     // 로그인 여부 확인하고 액세스토큰 없을 경우 403 에러 발생
@@ -29,7 +43,6 @@ export class UserGuard extends AuthGuard('jwt') {
     // 역할에 따라 요청 가능한 API: @Role('MAKER') 데코레이터 값에 따라 403 에러 발생
     const role = this.reflector.get(Role, context.getHandler());
     if (!role) return true;
-    const request = context.switchToHttp().getRequest();
     if (role !== request.user?.role) {
       throw new ForbiddenError(ErrorMessage.ROLE_FORBIDDEN);
     }

--- a/src/common/types/user/profile.types.ts
+++ b/src/common/types/user/profile.types.ts
@@ -18,3 +18,12 @@ export interface MakerProfileProperties extends BaseProfile {
   description: string;
   detailDescription: string;
 }
+
+export interface MakerInfoAndProfileProperties extends MakerProfileProperties {
+  id: string;
+  nickName: string;
+  averageRating: number;
+  totalReviews: number;
+  totalFollows: number;
+  totalConfirms: number;
+}

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, HttpCode, HttpStatus, Patch, Post, Query, Res } from '@nestjs/common';
+import { Body, Controller, Get, HttpCode, HttpStatus, Param, Patch, Post, Query, Res } from '@nestjs/common';
 import UserService from './user.service';
 import { Cookies } from 'src/common/decorators/cookie.decorator';
 import { Public } from 'src/common/decorators/public.decorator';
@@ -91,6 +91,12 @@ export default class UserController {
     return await this.service.getProfile(role, userId);
   }
 
+  @Public()
+  @Get('profile/:makerId')
+  async getProfileById(@Param('makerId') makerId: string, @UserId() dreamerId: string) {
+    return await this.service.getProfileCardData(makerId, dreamerId, true);
+  }
+
   @Get('following')
   @Role('DREAMER')
   async getFollowList(
@@ -123,9 +129,8 @@ export default class UserController {
   ) {
     if (role === 'DREAMER') {
       return await this.service.updateDreamerProfile(userId, data);
-    } else {
-      return await this.service.updateMakerProfile(userId, data);
     }
+    return await this.service.updateMakerProfile(userId, data);
   }
 
   @Public()

--- a/src/modules/user/user.repository.ts
+++ b/src/modules/user/user.repository.ts
@@ -47,7 +47,7 @@ export default class UserRepository {
         phoneNumber: true,
         coconut: true,
         nickName: true,
-        makerProfile: { select: { image: true, gallery: true, serviceTypes: true } },
+        makerProfile: true,
         followers: { select: { dreamerId: true } }
       }
     });

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -149,7 +149,7 @@ export default class UserService {
 
   async getProfileCardData(makerId: string, dreamerId: string, withDetails?: boolean): Promise<ProfileCardResponseDTO> {
     const user = await this.repository.findByIdWithProfileAndFollow(makerId);
-    const userData = user.getWithMakerProfile(withDetails ? true : false);
+    const userData = user.getWithMakerProfile(withDetails);
     const stats = await this.userStats.get(makerId);
 
     return {

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -6,7 +6,11 @@ import User from '../../common/domains/user/user.domain';
 import { JwtService } from '@nestjs/jwt';
 import { DreamerProfile, MakerProfile } from '../../common/domains/user/profile.domain';
 import { FilteredUserProperties, PasswordProperties, UserProperties } from '../../common/types/user/user.types';
-import { DreamerProfileProperties, MakerProfileProperties } from '../../common/types/user/profile.types';
+import {
+  DreamerProfileProperties,
+  MakerInfoAndProfileProperties,
+  MakerProfileProperties
+} from '../../common/types/user/profile.types';
 import UserStatsService from '../userStats/userStats.service';
 import { RoleEnum } from 'src/common/constants/role.type';
 import FollowService from '../follow/follow.service';
@@ -143,17 +147,13 @@ export default class UserService {
     return !user;
   }
 
-  async getProfileCardData(makerId: string, dreamerId: string): Promise<ProfileCardResponseDTO> {
+  async getProfileCardData(makerId: string, dreamerId: string, withDetails?: boolean): Promise<ProfileCardResponseDTO> {
     const user = await this.repository.findByIdWithProfileAndFollow(makerId);
-    const userData = user.get();
-    const profile = (await this.getProfile(RoleEnum.MAKER, makerId)) as MakerProfileProperties;
+    const userData = user.getWithMakerProfile(withDetails ? true : false);
     const stats = await this.userStats.get(makerId);
 
     return {
-      nickName: userData.nickName,
-      image: profile.image,
-      gallery: profile.gallery,
-      serviceTypes: profile.serviceTypes,
+      ...userData,
       isFollowed: user.isFollowed(dreamerId),
       ...stats
     };


### PR DESCRIPTION
## 작업한 이슈 번호

- close #133 

## 작업 사항 설명

Maker 상세페이지에서 userStats 데이터가 필요해서 userStats 포함한 프로필 조회 API를 추가합니다.

## 작업 사항

- [x] 메이커 ID를 통한 프로필 조회 API
- [x] 비회원 조회를 위한 @Public() 설정시 로그인한 유저의 찜 여부 확인을 위해 userId를 가져올 수 있도록 UserGuard 수정

## 기타

- 응답 예시
```
{
  "nickName": "장미",
  "image": "DEFAULT_4",
  "gallery": "https://www.instagram.com/codeit_kr/",
  "serviceTypes": [
    "RELAXATION",
    "SHOPPING"
  ],
  "serviceArea": [
    "SEOUL"
  ],
  "description": "여행의 꿈을 대신 이루어 드립니다!",
  "detailDescription": "안녕하세요! 여행을 좋아하고, 저희 지역을 소개하고 싶은 드림 메이커입니다 :) 드리머 여러분이 꿈꾸는 여행을 대신해서 이루어 드릴게요!",
  "isFollowed": true,
  "averageRating": 5,
  "totalReviews": 1,
  "totalFollows": 0,
  "totalConfirms": 0
}
```
