### PR TITLE
리뷰 목데이터 추가

### DIFF
--- a/src/providers/database/prisma/mock/plan.mock.ts
+++ b/src/providers/database/prisma/mock/plan.mock.ts
@@ -457,5 +457,182 @@ export const PLANS = [
     status: Status.PENDING,
     dreamerId: '66885a3c-50f4-427b-8a92-3702c6976fb0',
     assignees: [{ id: '032d7bd4-116c-467b-9352-a14b0d494ef9' }]
+  },
+  /** dreamer1, maker1 리뷰 생성용 목데이터 */
+  {
+    id: 'cf7abc6d-eca3-405a-bf6e-9071802b78ca',
+    createdAt: '2024-12-27T00:00:00.000Z',
+    title: '잠실 스카이타워 대신 올라가주세요',
+    tripDate: '2025-01-27T00:00:00.000Z',
+    tripType: TripType.ACTIVITY,
+    serviceArea: ServiceArea.SEOUL,
+    details: '고소공포증이 있어서 메이커님이 대신 제가 스카이타워 올라가는 것처럼 영상 찍어주세요',
+    status: Status.COMPLETED,
+    dreamerId: '66885a3c-50f4-427b-8a92-3702c6976fb0'
+  },
+  {
+    id: 'fc83c658-e960-4f50-bbad-390deda3979c',
+    createdAt: '2024-12-27T00:00:00.000Z',
+    title: '잠실 스카이타워 대신 올라가주세요',
+    tripDate: '2025-01-27T00:00:00.000Z',
+    tripType: TripType.ACTIVITY,
+    serviceArea: ServiceArea.SEOUL,
+    details: '고소공포증이 있어서 메이커님이 대신 제가 스카이타워 올라가는 것처럼 영상 찍어주세요',
+    status: Status.COMPLETED,
+    dreamerId: '66885a3c-50f4-427b-8a92-3702c6976fb0'
+  },
+  {
+    id: 'feccc484-4dce-48c0-8ccb-ffaeba1aca91',
+    createdAt: '2024-12-27T00:00:00.000Z',
+    title: '잠실 스카이타워 대신 올라가주세요',
+    tripDate: '2025-01-27T00:00:00.000Z',
+    tripType: TripType.ACTIVITY,
+    serviceArea: ServiceArea.SEOUL,
+    details: '고소공포증이 있어서 메이커님이 대신 제가 스카이타워 올라가는 것처럼 영상 찍어주세요',
+    status: Status.COMPLETED,
+    dreamerId: '66885a3c-50f4-427b-8a92-3702c6976fb0'
+  },
+  {
+    id: '62fa5235-b585-4e9a-8656-9bdc193f7349',
+    createdAt: '2024-12-27T00:00:00.000Z',
+    title: '잠실 스카이타워 대신 올라가주세요',
+    tripDate: '2025-01-27T00:00:00.000Z',
+    tripType: TripType.ACTIVITY,
+    serviceArea: ServiceArea.SEOUL,
+    details: '고소공포증이 있어서 메이커님이 대신 제가 스카이타워 올라가는 것처럼 영상 찍어주세요',
+    status: Status.COMPLETED,
+    dreamerId: '66885a3c-50f4-427b-8a92-3702c6976fb0'
+  },
+  {
+    id: '0f61f8b9-7b29-4b82-86c7-f7ce8e418baa',
+    createdAt: '2024-12-27T00:00:00.000Z',
+    title: '잠실 스카이타워 대신 올라가주세요',
+    tripDate: '2025-01-27T00:00:00.000Z',
+    tripType: TripType.ACTIVITY,
+    serviceArea: ServiceArea.SEOUL,
+    details: '고소공포증이 있어서 메이커님이 대신 제가 스카이타워 올라가는 것처럼 영상 찍어주세요',
+    status: Status.COMPLETED,
+    dreamerId: '66885a3c-50f4-427b-8a92-3702c6976fb0'
+  },
+  {
+    id: 'b89de5c8-da59-4400-b6b8-87a2badae2ab',
+    createdAt: '2024-12-27T00:00:00.000Z',
+    title: '잠실 스카이타워 대신 올라가주세요',
+    tripDate: '2025-01-27T00:00:00.000Z',
+    tripType: TripType.ACTIVITY,
+    serviceArea: ServiceArea.SEOUL,
+    details: '고소공포증이 있어서 메이커님이 대신 제가 스카이타워 올라가는 것처럼 영상 찍어주세요',
+    status: Status.COMPLETED,
+    dreamerId: '66885a3c-50f4-427b-8a92-3702c6976fb0'
+  },
+  {
+    id: '0a171359-56da-4384-9f54-36cb796e5412',
+    createdAt: '2024-12-27T00:00:00.000Z',
+    title: '잠실 스카이타워 대신 올라가주세요',
+    tripDate: '2025-01-27T00:00:00.000Z',
+    tripType: TripType.ACTIVITY,
+    serviceArea: ServiceArea.SEOUL,
+    details: '고소공포증이 있어서 메이커님이 대신 제가 스카이타워 올라가는 것처럼 영상 찍어주세요',
+    status: Status.COMPLETED,
+    dreamerId: '66885a3c-50f4-427b-8a92-3702c6976fb0'
+  },
+  {
+    id: '8c10d119-d5fe-4773-bd26-0d47cd57f530',
+    createdAt: '2024-12-27T00:00:00.000Z',
+    title: '잠실 스카이타워 대신 올라가주세요',
+    tripDate: '2025-01-27T00:00:00.000Z',
+    tripType: TripType.ACTIVITY,
+    serviceArea: ServiceArea.SEOUL,
+    details: '고소공포증이 있어서 메이커님이 대신 제가 스카이타워 올라가는 것처럼 영상 찍어주세요',
+    status: Status.COMPLETED,
+    dreamerId: '66885a3c-50f4-427b-8a92-3702c6976fb0'
+  },
+  {
+    id: '9a411e0b-7a54-4c84-b9fb-53cddbce5485',
+    createdAt: '2024-12-27T00:00:00.000Z',
+    title: '잠실 스카이타워 대신 올라가주세요',
+    tripDate: '2025-01-27T00:00:00.000Z',
+    tripType: TripType.ACTIVITY,
+    serviceArea: ServiceArea.SEOUL,
+    details: '고소공포증이 있어서 메이커님이 대신 제가 스카이타워 올라가는 것처럼 영상 찍어주세요',
+    status: Status.COMPLETED,
+    dreamerId: '66885a3c-50f4-427b-8a92-3702c6976fb0'
+  },
+  {
+    id: 'e6df9e0b-f3d2-42cf-a4b9-998ca536f93e',
+    createdAt: '2024-12-27T00:00:00.000Z',
+    title: '잠실 스카이타워 대신 올라가주세요',
+    tripDate: '2025-01-27T00:00:00.000Z',
+    tripType: TripType.ACTIVITY,
+    serviceArea: ServiceArea.SEOUL,
+    details: '고소공포증이 있어서 메이커님이 대신 제가 스카이타워 올라가는 것처럼 영상 찍어주세요',
+    status: Status.COMPLETED,
+    dreamerId: '66885a3c-50f4-427b-8a92-3702c6976fb0'
+  },
+  {
+    id: '095e42af-53af-4656-8335-2802b1cb369a',
+    createdAt: '2024-12-27T00:00:00.000Z',
+    title: '잠실 스카이타워 대신 올라가주세요',
+    tripDate: '2025-01-27T00:00:00.000Z',
+    tripType: TripType.ACTIVITY,
+    serviceArea: ServiceArea.SEOUL,
+    details: '고소공포증이 있어서 메이커님이 대신 제가 스카이타워 올라가는 것처럼 영상 찍어주세요',
+    status: Status.COMPLETED,
+    dreamerId: '66885a3c-50f4-427b-8a92-3702c6976fb0'
+  },
+  {
+    id: '5b345767-eec1-4107-925f-0ba60d940f7e',
+    createdAt: '2024-12-27T00:00:00.000Z',
+    title: '잠실 스카이타워 대신 올라가주세요',
+    tripDate: '2025-01-27T00:00:00.000Z',
+    tripType: TripType.ACTIVITY,
+    serviceArea: ServiceArea.SEOUL,
+    details: '고소공포증이 있어서 메이커님이 대신 제가 스카이타워 올라가는 것처럼 영상 찍어주세요',
+    status: Status.COMPLETED,
+    dreamerId: '66885a3c-50f4-427b-8a92-3702c6976fb0'
+  },
+  {
+    id: '01ec63ec-2c10-4a56-8aa2-638c8138ac8b',
+    createdAt: '2024-12-27T00:00:00.000Z',
+    title: '잠실 스카이타워 대신 올라가주세요',
+    tripDate: '2025-01-27T00:00:00.000Z',
+    tripType: TripType.ACTIVITY,
+    serviceArea: ServiceArea.SEOUL,
+    details: '고소공포증이 있어서 메이커님이 대신 제가 스카이타워 올라가는 것처럼 영상 찍어주세요',
+    status: Status.COMPLETED,
+    dreamerId: '66885a3c-50f4-427b-8a92-3702c6976fb0'
+  },
+  {
+    id: '1e747bc1-d11f-449b-9f4e-4b061a4129e0',
+    createdAt: '2024-12-27T00:00:00.000Z',
+    title: '잠실 스카이타워 대신 올라가주세요',
+    tripDate: '2025-01-27T00:00:00.000Z',
+    tripType: TripType.ACTIVITY,
+    serviceArea: ServiceArea.SEOUL,
+    details: '고소공포증이 있어서 메이커님이 대신 제가 스카이타워 올라가는 것처럼 영상 찍어주세요',
+    status: Status.COMPLETED,
+    dreamerId: '66885a3c-50f4-427b-8a92-3702c6976fb0'
+  },
+  {
+    id: 'bc9ad582-18f1-4825-9645-fe7d26bd0a78',
+    createdAt: '2024-12-27T00:00:00.000Z',
+    title: '잠실 스카이타워 대신 올라가주세요',
+    tripDate: '2025-01-27T00:00:00.000Z',
+    tripType: TripType.ACTIVITY,
+    serviceArea: ServiceArea.SEOUL,
+    details: '고소공포증이 있어서 메이커님이 대신 제가 스카이타워 올라가는 것처럼 영상 찍어주세요',
+    status: Status.COMPLETED,
+    dreamerId: '66885a3c-50f4-427b-8a92-3702c6976fb0'
+  },
+  {
+    id: 'ded63481-0cbb-4556-acc5-9c193fd1643b',
+    createdAt: '2024-12-27T00:00:00.000Z',
+    title: '잠실 스카이타워 대신 올라가주세요',
+    tripDate: '2025-01-27T00:00:00.000Z',
+    tripType: TripType.ACTIVITY,
+    serviceArea: ServiceArea.SEOUL,
+    details: '고소공포증이 있어서 메이커님이 대신 제가 스카이타워 올라가는 것처럼 영상 찍어주세요',
+    status: Status.COMPLETED,
+    dreamerId: '66885a3c-50f4-427b-8a92-3702c6976fb0'
   }
 ];

--- a/src/providers/database/prisma/mock/quote.mock.ts
+++ b/src/providers/database/prisma/mock/quote.mock.ts
@@ -558,5 +558,166 @@ export const QUOTES = [
     makerId: '6b4ded82-e680-410d-b86d-ce6974e53f37',
     isConfirmed: true,
     isAssigned: false
+  },
+  /** dreamer1, maker1 리뷰 생성용 목데이터 */
+  {
+    id: 'b9af04c8-eef2-4c09-a3de-ace146df24f8',
+    createdAt: '2024-12-28T00:00:00.000Z',
+    price: 100,
+    content: '높은 곳 좋아합니다!',
+    planId: 'cf7abc6d-eca3-405a-bf6e-9071802b78ca',
+    makerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
+    isConfirmed: true,
+    isAssigned: false
+  },
+  {
+    id: 'ae15710e-e6b9-464d-be7e-54ee8a95280f',
+    createdAt: '2024-12-28T00:00:00.000Z',
+    price: 100,
+    content: '높은 곳 좋아합니다!',
+    planId: 'fc83c658-e960-4f50-bbad-390deda3979c',
+    makerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
+    isConfirmed: true,
+    isAssigned: false
+  },
+  {
+    id: '875d3d33-d1aa-4e59-b1cf-e7e306b182fd',
+    createdAt: '2024-12-28T00:00:00.000Z',
+    price: 100,
+    content: '높은 곳 좋아합니다!',
+    planId: 'feccc484-4dce-48c0-8ccb-ffaeba1aca91',
+    makerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
+    isConfirmed: true,
+    isAssigned: false
+  },
+  {
+    id: '4a6d62bc-2066-436c-be21-b45dd7b4e5a2',
+    createdAt: '2024-12-28T00:00:00.000Z',
+    price: 100,
+    content: '높은 곳 좋아합니다!',
+    planId: '62fa5235-b585-4e9a-8656-9bdc193f7349',
+    makerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
+    isConfirmed: true,
+    isAssigned: false
+  },
+  {
+    id: '8d903f01-6181-4a36-a2cf-2f1543e09a77',
+    createdAt: '2024-12-28T00:00:00.000Z',
+    price: 100,
+    content: '높은 곳 좋아합니다!',
+    planId: '0f61f8b9-7b29-4b82-86c7-f7ce8e418baa',
+    makerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
+    isConfirmed: true,
+    isAssigned: false
+  },
+  {
+    id: '2dee7206-f5d3-442c-8613-8d22ff6e98c7',
+    createdAt: '2024-12-28T00:00:00.000Z',
+    price: 100,
+    content: '높은 곳 좋아합니다!',
+    planId: 'b89de5c8-da59-4400-b6b8-87a2badae2ab',
+    makerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
+    isConfirmed: true,
+    isAssigned: false
+  },
+  {
+    id: '5cc47a4d-13d7-463c-94a7-42d8e0df02b1',
+    createdAt: '2024-12-28T00:00:00.000Z',
+    price: 100,
+    content: '높은 곳 좋아합니다!',
+    planId: '0a171359-56da-4384-9f54-36cb796e5412',
+    makerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
+    isConfirmed: true,
+    isAssigned: false
+  },
+  {
+    id: 'f65e4f26-bdfd-4fe3-ba7a-d9d4c3db070c',
+    createdAt: '2024-12-28T00:00:00.000Z',
+    price: 100,
+    content: '높은 곳 좋아합니다!',
+    planId: '8c10d119-d5fe-4773-bd26-0d47cd57f530',
+    makerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
+    isConfirmed: true,
+    isAssigned: false
+  },
+  {
+    id: 'ae1e7476-5ef9-4f09-a92c-c71063772158',
+    createdAt: '2024-12-28T00:00:00.000Z',
+    price: 100,
+    content: '높은 곳 좋아합니다!',
+    planId: '9a411e0b-7a54-4c84-b9fb-53cddbce5485',
+    makerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
+    isConfirmed: true,
+    isAssigned: false
+  },
+  {
+    id: '413aecda-26cb-4ad3-92cb-f058d51a3940',
+    createdAt: '2024-12-28T00:00:00.000Z',
+    price: 100,
+    content: '높은 곳 좋아합니다!',
+    planId: 'e6df9e0b-f3d2-42cf-a4b9-998ca536f93e',
+    makerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
+    isConfirmed: true,
+    isAssigned: false
+  },
+  {
+    id: 'c305e4c4-d967-4a38-9246-1cb9f76181cb',
+    createdAt: '2024-12-28T00:00:00.000Z',
+    price: 100,
+    content: '높은 곳 좋아합니다!',
+    planId: '095e42af-53af-4656-8335-2802b1cb369a',
+    makerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
+    isConfirmed: true,
+    isAssigned: false
+  },
+  {
+    id: 'd4c62e20-232e-46ce-ae84-57b5c11911b3',
+    createdAt: '2024-12-28T00:00:00.000Z',
+    price: 100,
+    content: '높은 곳 좋아합니다!',
+    planId: '5b345767-eec1-4107-925f-0ba60d940f7e',
+    makerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
+    isConfirmed: true,
+    isAssigned: false
+  },
+  {
+    id: '706879e4-c1db-4392-8cf5-5ad66690bd01',
+    createdAt: '2024-12-28T00:00:00.000Z',
+    price: 100,
+    content: '높은 곳 좋아합니다!',
+    planId: '01ec63ec-2c10-4a56-8aa2-638c8138ac8b',
+    makerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
+    isConfirmed: true,
+    isAssigned: false
+  },
+  {
+    id: 'ff80eeb6-8b0f-41fd-8edf-e89c5384a56b',
+    createdAt: '2024-12-28T00:00:00.000Z',
+    price: 100,
+    content: '높은 곳 좋아합니다!',
+    planId: '1e747bc1-d11f-449b-9f4e-4b061a4129e0',
+    makerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
+    isConfirmed: true,
+    isAssigned: false
+  },
+  {
+    id: '09e18ed9-b0f6-4053-b5b3-b64770afec6a',
+    createdAt: '2024-12-28T00:00:00.000Z',
+    price: 100,
+    content: '높은 곳 좋아합니다!',
+    planId: 'bc9ad582-18f1-4825-9645-fe7d26bd0a78',
+    makerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
+    isConfirmed: true,
+    isAssigned: false
+  },
+  {
+    id: '7f6babc8-5f5c-47e3-a626-bc9da5687b16',
+    createdAt: '2024-12-28T00:00:00.000Z',
+    price: 100,
+    content: '높은 곳 좋아합니다!',
+    planId: 'ded63481-0cbb-4556-acc5-9c193fd1643b',
+    makerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
+    isConfirmed: true,
+    isAssigned: false
   }
 ];

--- a/src/providers/database/prisma/mock/review.mock.ts
+++ b/src/providers/database/prisma/mock/review.mock.ts
@@ -1,0 +1,98 @@
+export const REVIEWS = [
+  {
+    id: 'b1f27a6e-5f3c-4d7a-b3fc-0b14e3a6f8a5',
+    writerId: '66885a3c-50f4-427b-8a92-3702c6976fb0',
+    ownerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
+    rating: 5,
+    content: '정말 멋진 결과물을 전달해주셨고, 좋은 여행 해주셔서 감사합니다!',
+    planId: 'b198135d-9865-445b-a04b-742ca9939ee1'
+  },
+  {
+    id: '0a8efc76-fb52-4e82-9bb3-93e22752e314',
+    writerId: '66885a3c-50f4-427b-8a92-3702c6976fb0',
+    ownerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
+    rating: 5,
+    content: '대리 여행이 이렇게 만족스러울 줄 몰랐어요. 너무 좋았습니다!',
+    planId: 'b198135d-9865-445b-a04b-742ca9939ee1'
+  },
+  {
+    id: 'c3e9f862-79cb-4a08-a6e7-f1c3541d932a',
+    writerId: '66885a3c-50f4-427b-8a92-3702c6976fb0',
+    ownerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
+    rating: 5,
+    content: '덕분에 좋은 경험 했어요! 다음에도 부탁드릴게요.',
+    planId: 'b198135d-9865-445b-a04b-742ca9939ee1'
+  },
+  {
+    id: '1e72857f-80cc-4859-83a2-5a6473b86a75',
+    writerId: '66885a3c-50f4-427b-8a92-3702c6976fb0',
+    ownerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
+    rating: 5,
+    content: '기대 이상이었어요! 여행 후기도 감동적이었습니다.',
+    planId: 'b198135d-9865-445b-a04b-742ca9939ee1'
+  },
+  {
+    id: 'f6a5b8cd-91e5-42f4-8a9b-7ddffdb5a396',
+    writerId: '66885a3c-50f4-427b-8a92-3702c6976fb0',
+    ownerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
+    rating: 4,
+    content: '멋진 일정과 꼼꼼한 후기까지 최고였어요!',
+    planId: 'b198135d-9865-445b-a04b-742ca9939ee1'
+  },
+  {
+    id: 'ad22c3ea-b05b-47d2-b786-5292cf9c346e',
+    writerId: '66885a3c-50f4-427b-8a92-3702c6976fb0',
+    ownerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
+    rating: 4,
+    content: '이렇게 완벽한 여행이 될 줄이야! 감사해요!',
+    planId: 'b198135d-9865-445b-a04b-742ca9939ee1'
+  },
+  {
+    id: '4deee4ae-71b0-4f76-b9d3-45dd63c9c257',
+    writerId: '66885a3c-50f4-427b-8a92-3702c6976fb0',
+    ownerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
+    rating: 4,
+    content: '세심한 준비와 감동적인 스토리까지, 너무 좋았어요!',
+    planId: 'b198135d-9865-445b-a04b-742ca9939ee1'
+  },
+  {
+    id: '4c5cde24-39a5-4b1e-9e6a-5d18d933ea74',
+    writerId: '66885a3c-50f4-427b-8a92-3702c6976fb0',
+    ownerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
+    rating: 3,
+    content: '약간 아쉬운 부분도 있었지만 전반적으로 만족스러웠어요.',
+    planId: 'b198135d-9865-445b-a04b-742ca9939ee1'
+  },
+  {
+    id: '9805824b-2d43-461b-843f-258e5757ad18',
+    writerId: '66885a3c-50f4-427b-8a92-3702c6976fb0',
+    ownerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
+    rating: 3,
+    content: '전체적으로 괜찮았지만, 몇 가지 보완하면 더 좋을 것 같아요.',
+    planId: 'b198135d-9865-445b-a04b-742ca9939ee1'
+  },
+  {
+    id: '94f4f8a6-7448-488c-b7aa-87c6b2173e8d',
+    writerId: '66885a3c-50f4-427b-8a92-3702c6976fb0',
+    ownerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
+    rating: 3,
+    content: '좋았어요! 하지만 다음에는 더 개선될 수 있기를 바랍니다.',
+    planId: 'b198135d-9865-445b-a04b-742ca9939ee1'
+  },
+  {
+    id: '30556d26-b0ee-4b32-8690-4d37a5eb4c52',
+    writerId: '66885a3c-50f4-427b-8a92-3702c6976fb0',
+    ownerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
+    rating: 2,
+    content: '조금 아쉬운 부분도 있었지만, 전반적으로 좋았어요.',
+    planId: 'b198135d-9865-445b-a04b-742ca9939ee1'
+  },
+  {
+    id: '6dcd4eb5-14b6-4c97-896d-885df2f6b3b5',
+    writerId: '66885a3c-50f4-427b-8a92-3702c6976fb0',
+    ownerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
+    rating: 1,
+    content: '솔직히 좀 아쉬웠어요. 개선이 필요할 것 같아요.',
+    planId: 'b198135d-9865-445b-a04b-742ca9939ee1'
+  }
+];

--- a/src/providers/database/prisma/mock/review.mock.ts
+++ b/src/providers/database/prisma/mock/review.mock.ts
@@ -5,7 +5,7 @@ export const REVIEWS = [
     ownerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
     rating: 5,
     content: '정말 멋진 결과물을 전달해주셨고, 좋은 여행 해주셔서 감사합니다!',
-    planId: 'b198135d-9865-445b-a04b-742ca9939ee1'
+    planId: 'cf7abc6d-eca3-405a-bf6e-9071802b78ca'
   },
   {
     id: '0a8efc76-fb52-4e82-9bb3-93e22752e314',
@@ -13,7 +13,7 @@ export const REVIEWS = [
     ownerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
     rating: 5,
     content: '대리 여행이 이렇게 만족스러울 줄 몰랐어요. 너무 좋았습니다!',
-    planId: 'b198135d-9865-445b-a04b-742ca9939ee1'
+    planId: 'fc83c658-e960-4f50-bbad-390deda3979c'
   },
   {
     id: 'c3e9f862-79cb-4a08-a6e7-f1c3541d932a',
@@ -21,7 +21,7 @@ export const REVIEWS = [
     ownerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
     rating: 5,
     content: '덕분에 좋은 경험 했어요! 다음에도 부탁드릴게요.',
-    planId: 'b198135d-9865-445b-a04b-742ca9939ee1'
+    planId: 'feccc484-4dce-48c0-8ccb-ffaeba1aca91'
   },
   {
     id: '1e72857f-80cc-4859-83a2-5a6473b86a75',
@@ -29,7 +29,23 @@ export const REVIEWS = [
     ownerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
     rating: 5,
     content: '기대 이상이었어요! 여행 후기도 감동적이었습니다.',
-    planId: 'b198135d-9865-445b-a04b-742ca9939ee1'
+    planId: '62fa5235-b585-4e9a-8656-9bdc193f7349'
+  },
+  {
+    id: '634d3955-0a6c-4159-827c-f4f24264d57b',
+    writerId: '66885a3c-50f4-427b-8a92-3702c6976fb0',
+    ownerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
+    rating: 5,
+    content: '기대 이상이었어요! 여행 후기도 너무너무 감동적이었습니다.',
+    planId: '01ec63ec-2c10-4a56-8aa2-638c8138ac8b'
+  },
+  {
+    id: 'f8f9f8b1-f67b-4b3c-aac9-af481b45a635',
+    writerId: '66885a3c-50f4-427b-8a92-3702c6976fb0',
+    ownerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
+    rating: 5,
+    content: '메이커님 정말 감사합니다 !!! :)',
+    planId: 'ded63481-0cbb-4556-acc5-9c193fd1643b'
   },
   {
     id: 'f6a5b8cd-91e5-42f4-8a9b-7ddffdb5a396',
@@ -37,7 +53,7 @@ export const REVIEWS = [
     ownerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
     rating: 4,
     content: '멋진 일정과 꼼꼼한 후기까지 최고였어요!',
-    planId: 'b198135d-9865-445b-a04b-742ca9939ee1'
+    planId: '0f61f8b9-7b29-4b82-86c7-f7ce8e418baa'
   },
   {
     id: 'ad22c3ea-b05b-47d2-b786-5292cf9c346e',
@@ -45,7 +61,7 @@ export const REVIEWS = [
     ownerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
     rating: 4,
     content: '이렇게 완벽한 여행이 될 줄이야! 감사해요!',
-    planId: 'b198135d-9865-445b-a04b-742ca9939ee1'
+    planId: 'b89de5c8-da59-4400-b6b8-87a2badae2ab'
   },
   {
     id: '4deee4ae-71b0-4f76-b9d3-45dd63c9c257',
@@ -53,7 +69,15 @@ export const REVIEWS = [
     ownerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
     rating: 4,
     content: '세심한 준비와 감동적인 스토리까지, 너무 좋았어요!',
-    planId: 'b198135d-9865-445b-a04b-742ca9939ee1'
+    planId: '0a171359-56da-4384-9f54-36cb796e5412'
+  },
+  {
+    id: 'e42ba00c-cb1f-4a03-bd19-2e20341e778c',
+    writerId: '66885a3c-50f4-427b-8a92-3702c6976fb0',
+    ownerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
+    rating: 4,
+    content: '세심한 준비와 감동적인 스토리까지, 정말 메이커님 감사합니다!',
+    planId: '1e747bc1-d11f-449b-9f4e-4b061a4129e0'
   },
   {
     id: '4c5cde24-39a5-4b1e-9e6a-5d18d933ea74',
@@ -61,7 +85,15 @@ export const REVIEWS = [
     ownerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
     rating: 3,
     content: '약간 아쉬운 부분도 있었지만 전반적으로 만족스러웠어요.',
-    planId: 'b198135d-9865-445b-a04b-742ca9939ee1'
+    planId: '8c10d119-d5fe-4773-bd26-0d47cd57f530'
+  },
+  {
+    id: 'c45430d9-4ea9-4b3a-8c7b-dffed6609bf0',
+    writerId: '66885a3c-50f4-427b-8a92-3702c6976fb0',
+    ownerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
+    rating: 3,
+    content: '메이커님은 친절하고 좋으셨어요.',
+    planId: 'bc9ad582-18f1-4825-9645-fe7d26bd0a78'
   },
   {
     id: '9805824b-2d43-461b-843f-258e5757ad18',
@@ -69,7 +101,7 @@ export const REVIEWS = [
     ownerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
     rating: 3,
     content: '전체적으로 괜찮았지만, 몇 가지 보완하면 더 좋을 것 같아요.',
-    planId: 'b198135d-9865-445b-a04b-742ca9939ee1'
+    planId: '9a411e0b-7a54-4c84-b9fb-53cddbce5485'
   },
   {
     id: '94f4f8a6-7448-488c-b7aa-87c6b2173e8d',
@@ -77,7 +109,7 @@ export const REVIEWS = [
     ownerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
     rating: 3,
     content: '좋았어요! 하지만 다음에는 더 개선될 수 있기를 바랍니다.',
-    planId: 'b198135d-9865-445b-a04b-742ca9939ee1'
+    planId: 'e6df9e0b-f3d2-42cf-a4b9-998ca536f93e'
   },
   {
     id: '30556d26-b0ee-4b32-8690-4d37a5eb4c52',
@@ -85,7 +117,15 @@ export const REVIEWS = [
     ownerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
     rating: 2,
     content: '조금 아쉬운 부분도 있었지만, 전반적으로 좋았어요.',
-    planId: 'b198135d-9865-445b-a04b-742ca9939ee1'
+    planId: '095e42af-53af-4656-8335-2802b1cb369a'
+  },
+  {
+    id: '84b998ac-2f3e-4502-a6aa-3f1053700d9f',
+    writerId: '66885a3c-50f4-427b-8a92-3702c6976fb0',
+    ownerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
+    rating: 2,
+    content: '아주 조금 아쉬운 부분도 있었지만, 전반적으로는 좋았습니다~!',
+    planId: '1e747bc1-d11f-449b-9f4e-4b061a4129e0'
   },
   {
     id: '6dcd4eb5-14b6-4c97-896d-885df2f6b3b5',
@@ -93,6 +133,6 @@ export const REVIEWS = [
     ownerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
     rating: 1,
     content: '솔직히 좀 아쉬웠어요. 개선이 필요할 것 같아요.',
-    planId: 'b198135d-9865-445b-a04b-742ca9939ee1'
+    planId: '5b345767-eec1-4107-925f-0ba60d940f7e'
   }
 ];

--- a/src/providers/database/prisma/mock/userStats.mock.ts
+++ b/src/providers/database/prisma/mock/userStats.mock.ts
@@ -1,0 +1,9 @@
+export const USER_STATS = [
+  {
+    userId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
+    averageRating: 3.6875,
+    totalReviews: 16,
+    totalFollows: 10,
+    totalConfirms: 20
+  }
+];

--- a/src/providers/database/prisma/prisma.seed.ts
+++ b/src/providers/database/prisma/prisma.seed.ts
@@ -18,14 +18,14 @@ async function main(prisma: PrismaDBClient) {
       password: await HashingPassword(user.password)
     }))
   );
+  await prisma.review.deleteMany();
   await prisma.quote.deleteMany();
   await prisma.plan.deleteMany();
   await prisma.follow.deleteMany();
   await prisma.makerProfile.deleteMany();
   await prisma.dreamerProfile.deleteMany();
-  await prisma.user.deleteMany();
-  await prisma.review.deleteMany();
   await prisma.userStats.deleteMany();
+  await prisma.user.deleteMany();
 
   await prisma.user.createMany({
     data: users,

--- a/src/providers/database/prisma/prisma.seed.ts
+++ b/src/providers/database/prisma/prisma.seed.ts
@@ -8,6 +8,8 @@ import { MAKER_PROFILES } from './mock/makerProfile.mock';
 import { FOLLOWS } from './mock/follow.mock';
 import { HashingPassword } from 'src/common/utilities/hashingPassword';
 import { QUOTES } from './mock/quote.mock';
+import { USER_STATS } from './mock/userStats.mock';
+import { REVIEWS } from './mock/review.mock';
 
 async function main(prisma: PrismaDBClient) {
   const users = await Promise.all(
@@ -22,6 +24,8 @@ async function main(prisma: PrismaDBClient) {
   await prisma.makerProfile.deleteMany();
   await prisma.dreamerProfile.deleteMany();
   await prisma.user.deleteMany();
+  await prisma.review.deleteMany();
+  await prisma.userStats.deleteMany();
 
   await prisma.user.createMany({
     data: users,
@@ -54,6 +58,14 @@ async function main(prisma: PrismaDBClient) {
 
   await prisma.quote.createMany({
     data: QUOTES,
+    skipDuplicates: true
+  });
+  await prisma.userStats.createMany({
+    data: USER_STATS,
+    skipDuplicates: true
+  });
+  await prisma.review.createMany({
+    data: REVIEWS,
     skipDuplicates: true
   });
 


### PR DESCRIPTION
## 작업한 이슈 번호

- close #159 

## 작업 사항 설명

리뷰 목데이터를 추가합니다.

## 작업 사항

- [x] 리뷰 목데이터 16개 추가 (maker1, dreamer1)
- [x] 리뷰에 연결할 Plan, Quote 목데이터 16개씩 추가
- [x] maker1 UserStats 목데이터 임시 추가

## 기타

- userStats 목데이터는 별도로 정리해서 추가할 예정이고, 프론트엔드 작업을 위해 maker1 데이터만 임시로 추가합니다.
