### PR TITLE
카카오 간편로그인 API 구현

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 PORT=4000
 
 # POSTGRESQL
-DATABASE_URL="DATABASE_URL="postgresql://goforme_postgresql_db_qxsm_user:9wew1RGzKHjy9CLpcBoSWsawhaCGcKGq@dpg-cuilqkbqf0us73dquvmg-a.singapore-postgres.render.com/goforme_postgresql_db_qxsm""
+DATABASE_URL="postgresql://goforme_postgresql_db_qxsm_user:9wew1RGzKHjy9CLpcBoSWsawhaCGcKGq@dpg-cuilqkbqf0us73dquvmg-a.singapore-postgres.render.com/goforme_postgresql_db_qxsm"
 
 # MONGODB
 MONGO_DB_NAME="GoHawaiiForMe"
@@ -19,6 +19,12 @@ REFRESH_TOKEN_EXPIRY="1w"
 GOOGLE_CLIENT_ID=""
 GOOGLE_CLIENT_SECRET=""
 GOOGLE_REDIRECT=""
+KAKAO_CLIENT_ID=""
+KAKAO_CLIENT_SECRET=""
+KAKAO_REDIRECT=""
+NAVER_CLIENT_ID=""
+NAVER_CLIENT_SECRET=""
+NAVER_REDIRECT=""
 
 # REDIS
 REDIS_HOST="127.0.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "passport": "^0.7.0",
         "passport-google-oauth20": "^2.0.0",
         "passport-jwt": "^4.0.1",
+        "passport-kakao": "^1.0.1",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
         "uuid": "^11.0.4"
@@ -54,6 +55,7 @@
         "@types/node": "^20.3.1",
         "@types/passport-google-oauth20": "^2.0.16",
         "@types/passport-jwt": "^4.0.1",
+        "@types/passport-kakao": "^1.0.3",
         "@types/supertest": "^6.0.0",
         "@typescript-eslint/eslint-plugin": "^5.0.0",
         "@typescript-eslint/parser": "^5.0.0",
@@ -4328,6 +4330,17 @@
       "dependencies": {
         "@types/jsonwebtoken": "*",
         "@types/passport-strategy": "*"
+      }
+    },
+    "node_modules/@types/passport-kakao": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/passport-kakao/-/passport-kakao-1.0.3.tgz",
+      "integrity": "sha512-McK5kpeiOptvjIPkiA/QS3k82//z5JM7Y3yBLMDvEA0QMMhFMcWUHhyebL1Qy+0i0n8jS+Oe4U6xAvkU22SXXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/passport": "*"
       }
     },
     "node_modules/@types/passport-oauth2": {
@@ -11507,6 +11520,35 @@
         "passport-strategy": "^1.0.0"
       }
     },
+    "node_modules/passport-kakao": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/passport-kakao/-/passport-kakao-1.0.1.tgz",
+      "integrity": "sha512-uItaYRVrTHL6iGPMnMZvPa/O1GrAdh/V6EMjOHcFlQcVroZ9wgG7BZ5PonMNJCxfHQ3L2QVNRnzhKWUzSsumbw==",
+      "license": "MIT",
+      "dependencies": {
+        "passport-oauth2": "~1.1.2",
+        "pkginfo": "~0.3.0"
+      }
+    },
+    "node_modules/passport-kakao/node_modules/oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==",
+      "license": "MIT"
+    },
+    "node_modules/passport-kakao/node_modules/passport-oauth2": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.1.2.tgz",
+      "integrity": "sha512-wpsGtJDHHQUjyc9WcV9FFB0bphFExpmKtzkQrxpH1vnSr6RcWa3ZEGHx/zGKAh2PN7Po9TKYB1fJeOiIBspNPA==",
+      "dependencies": {
+        "oauth": "0.9.x",
+        "passport-strategy": "1.x.x",
+        "uid2": "0.0.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/passport-oauth2": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.8.0.tgz",
@@ -11714,6 +11756,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pkginfo": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
+      "integrity": "sha512-yO5feByMzAp96LtP58wvPKSbaKAi/1C4kV9XpTctr6EepnP6F33RBNOiVrdz9BrPA98U2BMFsTNHo44TWcbQ2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/pluralize": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",
     "passport-jwt": "^4.0.1",
+    "passport-kakao": "^1.0.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "uuid": "^11.0.4"
@@ -69,6 +70,7 @@
     "@types/node": "^20.3.1",
     "@types/passport-google-oauth20": "^2.0.16",
     "@types/passport-jwt": "^4.0.1",
+    "@types/passport-kakao": "^1.0.3",
     "@types/supertest": "^6.0.0",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",

--- a/src/common/constants/errorMessage.enum.ts
+++ b/src/common/constants/errorMessage.enum.ts
@@ -12,6 +12,8 @@ export enum ErrorMessage {
   USER_COCONUT_INVALID = '포인트는 0코코넛 이상이어야 합니다.',
 
   OAUTH_GOOGLE_SERVER_ERROR = '구글 프로필 정보를 가져올 수 없습니다.',
+  OAUTH_KAKAO_SERVER_ERROR = '카카오 프로필 정보를 가져올 수 없습니다.',
+  OAUTH_NAVER_SERVER_ERROR = '네이버 프로필 정보를 가져올 수 없습니다.',
 
   TOKEN_UNAUTHORIZED_NOTFOUND = '토큰이 없습니다. 로그인이 필요합니다',
   TOKEN_UNAUTHORIZED_VALIDATION = '유효하지 않은 토큰입니다',

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -7,6 +7,7 @@ import AuthRepository from './auth.repository';
 import AuthService from './auth.service';
 import { GoogleStrategy } from './strategy/google.strategy';
 import AuthController from './auth.controller';
+import { KakaoStrategy } from './strategy/kakao.strategy';
 
 @Module({
   imports: [
@@ -17,7 +18,7 @@ import AuthController from './auth.controller';
     UserStatsModule
   ],
   controllers: [AuthController],
-  providers: [AuthService, AuthRepository, JwtStrategy, GoogleStrategy],
+  providers: [AuthService, AuthRepository, JwtStrategy, GoogleStrategy, KakaoStrategy],
   exports: []
 })
 export default class AuthModule {}

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -68,7 +68,7 @@ export default class AuthService {
     return user.toClient();
   }
 
-  async googleLogin(data: OAuthProperties) {
+  async socialLogin(data: OAuthProperties) {
     const user = await this.repository.findByProviderId(data.providerId);
     if (!user) return null;
 

--- a/src/modules/auth/strategy/google.strategy.ts
+++ b/src/modules/auth/strategy/google.strategy.ts
@@ -19,10 +19,7 @@ export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
   validate(accessToken: string, refreshToken: string, profile: Profile) {
     if (!profile) throw new InternalServerError(ErrorMessage.OAUTH_GOOGLE_SERVER_ERROR);
 
-    const user = {
-      provider: OAuthProviderEnum.GOOGLE,
-      providerId: profile.id
-    };
+    const user = { provider: OAuthProviderEnum.GOOGLE, providerId: profile.id };
 
     return user;
   }

--- a/src/modules/auth/strategy/kakao.strategy.ts
+++ b/src/modules/auth/strategy/kakao.strategy.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { Profile, Strategy } from 'passport-kakao';
+import ErrorMessage from 'src/common/constants/errorMessage.enum';
+import { OAuthProviderEnum } from 'src/common/constants/oauth.type';
+import InternalServerError from 'src/common/errors/internalServerError';
+
+@Injectable()
+export class KakaoStrategy extends PassportStrategy(Strategy, 'kakao') {
+  constructor() {
+    super({
+      clientID: process.env.KAKAO_CLIENT_ID,
+      clientSecret: process.env.KAKAO_CLIENT_SECRET,
+      callbackURL: process.env.KAKAO_REDIRECT
+    });
+  }
+
+  validate(accessToken: string, refreshToken: string, profile: Profile) {
+    if (!profile) throw new InternalServerError(ErrorMessage.OAUTH_KAKAO_SERVER_ERROR);
+
+    const { _json } = profile;
+    const user = { provider: OAuthProviderEnum.KAKAO, providerId: String(_json.id) };
+
+    return user;
+  }
+}


### PR DESCRIPTION
## 작업한 이슈 번호

- close #168 

## 작업 사항 설명

카카오 간편 로그인 구현

## 작업 사항

- [x] Passport를 통한 카카오 간편 로그인 API

## 기타

- AuthService의 socialLogin 메서드를 하나로 통합
