### PR TITLE
간편 로그인 로직 수정

### DIFF
--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -57,8 +57,10 @@ export default class AuthController {
 
   @Public()
   @Get('google')
-  @UseGuards(AuthGuard('google'))
-  async toGoogle() {} // 구글 로그인 페이지로 Redirect
+  toGoogle(): { redirectUrl: string } {
+    const redirectUrl = `https://accounts.google.com/o/oauth2/auth?client_id=${process.env.GOOGLE_CLIENT_ID}&redirect_uri=${process.env.GOOGLE_REDIRECT}&response_type=code&scope=email profile`;
+    return { redirectUrl };
+  }
 
   @Public()
   @UseGuards(AuthGuard('google'))
@@ -83,10 +85,9 @@ export default class AuthController {
 
   @Public()
   @Get('kakao')
-  @UseGuards(AuthGuard('kakao'))
-  toKakao(@Res() res: Response): void {
-    const kakaoUrl = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${process.env.KAKAO_CLIENT_ID}&redirect_uri=${process.env.KAKAO_REDIRECT}`;
-    return res.redirect(kakaoUrl);
+  toKakao(): { redirectUrl: string } {
+    const redirectUrl = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${process.env.KAKAO_CLIENT_ID}&redirect_uri=${process.env.KAKAO_REDIRECT}`;
+    return { redirectUrl };
   }
 
   @Public()


### PR DESCRIPTION
## 작업한 이슈 번호

- close #181 

## 작업 사항 설명

간편 로그인시 서버에서 리다이렉트 할 때 CORS 문제가 발생하여, 클라이언트에서 로그인 후 서버로 콜백하는 로직을 수정합니다.

## 작업 사항

- [x] 현재 구현된 구글, 카카오 로그인 로직 수정

## 기타

- 
