### PR TITLE
채팅 메시지 삭제 구현

### DIFF
--- a/httpTest/chat.http
+++ b/httpTest/chat.http
@@ -4,7 +4,7 @@
 GET http://localhost:4000/chatRooms
 Authorization: Bearer {{DREAMER1_TOKEN}}
 ###
-GET http://localhost:4000/chatRooms/{{EXAMPLE_CHAT_ROOM}}
+GET http://localhost:4000/chatRooms/{{EXAMPLE_CHAT_ROOM}}/chats
 Authorization: Bearer {{DREAMER1_TOKEN}}
 ###
 GET http://localhost:4000/chatRooms/{{CHATROOM1_ID}}/chats

--- a/httpTest/chat.http
+++ b/httpTest/chat.http
@@ -1,16 +1,16 @@
 @DREAMER1_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiI2Njg4NWEzYy01MGY0LTQyN2ItOGE5Mi0zNzAyYzY5NzZmYjAiLCJyb2xlIjoiRFJFQU1FUiIsImlhdCI6MTczNzk4MzQ1MSwiZXhwIjoxNzQxNDM5NDUxfQ.V2qa2oB-m757NnAXYkefAWL_Vewwh526s97SYh2LuJc
 @CHATROOM1_ID=67a4e29ba4b7b6ddc6ef5ac6
-
+@EXAMPLE_CHAT_ROOM=67a4e29ba4b7b6ddc6ef5ac6
 GET http://localhost:4000/chatRooms
 Authorization: Bearer {{DREAMER1_TOKEN}}
 ###
-GET http://localhost:4000/chatRooms/{{CHATROOM1_ID}}
+GET http://localhost:4000/chatRooms/{{EXAMPLE_CHAT_ROOM}}
 Authorization: Bearer {{DREAMER1_TOKEN}}
 ###
 GET http://localhost:4000/chatRooms/{{CHATROOM1_ID}}/chats
 Authorization: Bearer {{DREAMER1_TOKEN}}
 ###
-DELETE http://localhost:4000/chats/67a4e2f016d81504cec91f72
+DELETE http://localhost:4000/chats/67a5beeed80a6a8eb3a6c3d6
 Authorization: Bearer {{DREAMER1_TOKEN}}
 ###
 POST http://localhost:4000/chatRooms

--- a/src/common/constants/errorMessage.enum.ts
+++ b/src/common/constants/errorMessage.enum.ts
@@ -72,12 +72,14 @@ export enum ErrorMessage {
   CHAT_ROOM_BAD_VALUE = '입력한 채팅방의 값이 잘못되었습니다.',
 
   CHAT_POST_BAD_ID = '채팅방의 id가 잘못된 형식입니다.',
-  CHAT_NOT_FOUND_ERROR = '이미 삭제됐거나 없는 채팅입니다.',
+  CHAT_NOT_FOUND_ERROR = '해당 채팅을 찾을 수 없습니다.',
   CHAT_UPLOAD_TYPE_TEXT = '업로드 파일의 타입이 없거나 TEXT입니다.',
   CHAT_NOT_FILE_REQUEST = '서버에 전해진 업로드할 파일이 없습니다.',
   CHAT_FILE_SIZE_NOT_VIDEO = '동영상을 제외한 모든 파일 크기 제한은 2MB입니다.',
   CHAT_FILE_SIZE_VIDEO = '동영상의 파일 크기 제한은 100MB입니다.',
   CHAT_FILE_TYPE_NOT_SUPPORTED = '지원하지 않는 파일 형식입니다',
+  CHAT_FORBIDDEN_DELETE = '채팅 메시지를 작성한 당사자만 삭제할 수 있습니다.',
+  CHAT_CONFLICT_DELETE = '이미 삭제된 메시지입니다.',
 
   CLIENT_NOT_CONNECTED = '연결되지 않은 클라이언트입니다.',
 

--- a/src/common/constants/errorMessage.enum.ts
+++ b/src/common/constants/errorMessage.enum.ts
@@ -72,6 +72,7 @@ export enum ErrorMessage {
   CHAT_ROOM_BAD_VALUE = '입력한 채팅방의 값이 잘못되었습니다.',
 
   CHAT_POST_BAD_ID = '채팅방의 id가 잘못된 형식입니다.',
+  CHAT_NOT_FOUND_ERROR = '이미 삭제됐거나 없는 채팅입니다.',
   CHAT_UPLOAD_TYPE_TEXT = '업로드 파일의 타입이 없거나 TEXT입니다.',
   CHAT_NOT_FILE_REQUEST = '서버에 전해진 업로드할 파일이 없습니다.',
   CHAT_FILE_SIZE_NOT_VIDEO = '동영상을 제외한 모든 파일 크기 제한은 2MB입니다.',

--- a/src/common/domains/chat/chat.domain.ts
+++ b/src/common/domains/chat/chat.domain.ts
@@ -62,4 +62,16 @@ export default class Chat implements IChat {
   setS3Key(s3key: string): void {
     this.content = s3key;
   }
+
+  getChatRoomId(): string {
+    return this.chatRoomId;
+  }
+
+  getSenderId(): string {
+    return this.senderId;
+  }
+
+  getIsDeletedAt(): Date {
+    return this.isDeletedAt;
+  }
 }

--- a/src/common/domains/chat/chat.domain.ts
+++ b/src/common/domains/chat/chat.domain.ts
@@ -6,6 +6,7 @@ export default class Chat implements IChat {
   private id?: string;
   private createdAt?: Date;
   private updatedAt?: Date;
+  private isDeletedAt?: Date | null;
   private type: ChatType;
   private senderId: string | null;
   private chatRoomId: string;
@@ -16,6 +17,7 @@ export default class Chat implements IChat {
     this.id = chat?.id;
     this.createdAt = chat.createdAt;
     this.updatedAt = chat.updatedAt;
+    this.isDeletedAt = chat.isDeletedAt;
     this.type = chat.type;
     this.senderId = chat.senderId;
     this.chatRoomId = chat.chatRoomId;
@@ -42,6 +44,7 @@ export default class Chat implements IChat {
       id: this.id,
       createdAt: this.createdAt,
       updatedAt: this.updatedAt,
+      isDeletedAt: this.isDeletedAt,
       type: this.type,
       senderId: this.senderId,
       chatRoomId: this.chatRoomId,

--- a/src/common/domains/chat/chat.interface.ts
+++ b/src/common/domains/chat/chat.interface.ts
@@ -5,4 +5,7 @@ export default interface IChat {
   toClient(): ChatToClientProperties;
   toS3(): ChatToS3Properties;
   setS3Key(s3key: string): void;
+  getChatRoomId(): string;
+  getSenderId(): string;
+  getIsDeletedAt(): Date;
 }

--- a/src/common/domains/chat/chat.mapper.ts
+++ b/src/common/domains/chat/chat.mapper.ts
@@ -8,14 +8,17 @@ export default class ChatMapper {
   toDomain(): IChat {
     if (!this.chat) return null;
 
-    return new Chat({
+    const result = new Chat({
       id: this.chat._id.toString(),
       createdAt: this.chat.createdAt,
       updatedAt: this.chat.updatedAt,
+      isDeletedAt: this.chat.isDeletedAt,
       type: this.chat.type,
       senderId: this.chat.senderId,
       chatRoomId: this.chat.chatRoomId.toString(),
       content: this.chat.content
     });
+    //console.log(result);
+    return result;
   }
 }

--- a/src/common/domains/chat/chat.mapper.ts
+++ b/src/common/domains/chat/chat.mapper.ts
@@ -8,7 +8,7 @@ export default class ChatMapper {
   toDomain(): IChat {
     if (!this.chat) return null;
 
-    const result = new Chat({
+    return new Chat({
       id: this.chat._id.toString(),
       createdAt: this.chat.createdAt,
       updatedAt: this.chat.updatedAt,
@@ -18,6 +18,5 @@ export default class ChatMapper {
       chatRoomId: this.chat.chatRoomId.toString(),
       content: this.chat.content
     });
-    return result;
   }
 }

--- a/src/common/domains/chat/chat.mapper.ts
+++ b/src/common/domains/chat/chat.mapper.ts
@@ -18,7 +18,6 @@ export default class ChatMapper {
       chatRoomId: this.chat.chatRoomId.toString(),
       content: this.chat.content
     });
-    //console.log(result);
     return result;
   }
 }

--- a/src/common/domains/chat/chat.properties.ts
+++ b/src/common/domains/chat/chat.properties.ts
@@ -4,6 +4,7 @@ export interface ChatProperties {
   id?: string;
   createdAt?: Date;
   updatedAt?: Date;
+  isDeletedAt?: Date | null;
   type: ChatType;
   chatRoomId: string;
   senderId: string | null;
@@ -15,6 +16,8 @@ export interface ChatToClientProperties {
   id: string;
   createdAt: Date;
   updatedAt: Date;
+  isDeletedAt?: Date | null;
+  isDeleted?: boolean;
   type: ChatType;
   chatRoomId: string;
   senderId: string | null;

--- a/src/common/types/chatRoom/chatRoom.type.ts
+++ b/src/common/types/chatRoom/chatRoom.type.ts
@@ -14,7 +14,6 @@ export interface FindChatRoomByIdOptions {
   userId?: string;
   chatRoomId?: string;
   planId?: string;
-  chatId?: string;
 }
 
 export interface FileUploadData {

--- a/src/common/types/chatRoom/chatRoom.type.ts
+++ b/src/common/types/chatRoom/chatRoom.type.ts
@@ -4,6 +4,7 @@ export interface ChatReference {
   id: string;
   createdAt: Date;
   updatedAt: Date;
+  isDeleted?: boolean;
   chatRoomId: string;
   senderId: string | null;
   content: string;

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,8 @@ async function bootstrap() {
   });
   app.use(cookieParser());
 
-  app.useGlobalPipes(new ValidationPipe({ transform: true })).useGlobalFilters(new GlobalExceptionFilter());
+  app.useGlobalPipes(new ValidationPipe({ transform: true }));
+  //.useGlobalFilters(new GlobalExceptionFilter());
 
   // swagger 세부 세팅 참고 : https://docs.nestjs.com/openapi/introduction
   const config = new DocumentBuilder()

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,8 +19,7 @@ async function bootstrap() {
   });
   app.use(cookieParser());
 
-  app.useGlobalPipes(new ValidationPipe({ transform: true }));
-  //.useGlobalFilters(new GlobalExceptionFilter());
+  app.useGlobalPipes(new ValidationPipe({ transform: true })).useGlobalFilters(new GlobalExceptionFilter());
 
   // swagger 세부 세팅 참고 : https://docs.nestjs.com/openapi/introduction
   const config = new DocumentBuilder()

--- a/src/modules/chat/chat.controller.ts
+++ b/src/modules/chat/chat.controller.ts
@@ -1,12 +1,14 @@
 import { Controller, Delete, HttpCode, HttpStatus, Param } from '@nestjs/common';
 import ChatService from './chat.service';
+import { UserId } from 'src/common/decorators/user.decorator';
 
 @Controller('chats')
 export default class ChatController {
   constructor(private readonly chatService: ChatService) {}
+
   @Delete(':id')
   @HttpCode(HttpStatus.NO_CONTENT)
-  async deleteChat(@Param('id') id: string): Promise<void> {
-    await this.chatService.deleteChat(id);
+  async deleteChat(@UserId() userId: string, @Param('id') id: string): Promise<void> {
+    await this.chatService.deleteChat({ userId, id });
   }
 }

--- a/src/modules/chat/chat.controller.ts
+++ b/src/modules/chat/chat.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Delete, HttpCode, HttpStatus, Param } from '@nestjs/common';
+import ChatService from './chat.service';
+
+@Controller('chats')
+export default class ChatController {
+  constructor(private readonly chatService: ChatService) {}
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async deleteChat(@Param('id') id: string): Promise<void> {
+    await this.chatService.deleteChat(id);
+  }
+}

--- a/src/modules/chat/chat.module.ts
+++ b/src/modules/chat/chat.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import ChatService from './chat.service';
 import { JwtModule } from '@nestjs/jwt';
 import { MongooseModule } from '@nestjs/mongoose';
@@ -6,6 +6,8 @@ import ChatRoomSchema, { ChatRoom } from 'src/providers/database/mongoose/chatRo
 import ChatSchema, { Chat } from 'src/providers/database/mongoose/chat.schema';
 import ChatRepository from './chat.repository';
 import S3Module from 'src/providers/storage/s3/s3.module';
+import ChatController from './chat.controller';
+import ChatRoomModule from '../chatRoom/chatRoom.module';
 
 @Module({
   imports: [
@@ -16,8 +18,10 @@ import S3Module from 'src/providers/storage/s3/s3.module';
       { name: ChatRoom.name, schema: ChatRoomSchema },
       { name: Chat.name, schema: ChatSchema }
     ]),
-    S3Module
+    S3Module,
+    forwardRef(() => ChatRoomModule)
   ],
+  controllers: [ChatController],
   providers: [ChatService, ChatRepository],
   exports: [ChatService]
 })

--- a/src/modules/chat/chat.repository.ts
+++ b/src/modules/chat/chat.repository.ts
@@ -54,7 +54,7 @@ export default class ChatRepository {
     );
     if (chatRoom.modifiedCount === 0) {
       throw new InternalServerError(ErrorMessage.INTERNAL_SERVER_ERROR_CHAT_ROOM_UPDATE);
-    }
+    } //TODO. 레포분리 및 transaction
 
     const domainChat = new ChatMapper(chat).toDomain();
 

--- a/src/modules/chat/chat.service.ts
+++ b/src/modules/chat/chat.service.ts
@@ -56,11 +56,10 @@ export default class ChatService {
     }
     const chat = await this.chatRepository.delete(id); //TODO. transaction
     if (!chat) throw new NotFoundError(ErrorMessage.CHAT_NOT_FOUND_ERROR);
-    console.log(this.convertToClient(chat.toClient()));
   }
 
   private async convertToClient(chatData: ChatToClientProperties): Promise<ChatToClientProperties> {
-    const { content, isDeletedAt, ...rest }: ChatToClientProperties = chatData;
+    const { content, isDeletedAt, ...rest } = chatData;
     let updatedContent = content;
 
     if (isDeletedAt) {

--- a/src/modules/chat/chat.service.ts
+++ b/src/modules/chat/chat.service.ts
@@ -65,19 +65,19 @@ export default class ChatService {
     if (isDeletedAt) {
       rest.isDeleted = true;
       switch (chatData.type) {
-        case 'TEXT':
+        case ChatType.TEXT:
           updatedContent = '삭제된 메시지입니다.';
           break;
-        case 'IMAGE':
+        case ChatType.IMAGE:
           updatedContent = '삭제된 이미지입니다.';
           break;
-        case 'VIDEO':
+        case ChatType.VIDEO:
           updatedContent = '삭제된 동영상입니다.';
           break;
       }
     } else {
       rest.isDeleted = false;
-      if (chatData.type === 'TEXT') {
+      if (chatData.type === ChatType.TEXT) {
         updatedContent = content;
       } else {
         updatedContent = await this.s3Service.generatePresignedUrl(content);

--- a/src/modules/chat/chat.service.ts
+++ b/src/modules/chat/chat.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import ChatRepository from './chat.repository';
 import { ChatCreateData, ChatQueryOptions } from 'src/common/types/chat/chat.type';
 import Chat from 'src/common/domains/chat/chat.domain';
@@ -6,12 +6,17 @@ import { ChatToClientProperties } from 'src/common/domains/chat/chat.properties'
 import { FileUploadData } from 'src/common/types/chatRoom/chatRoom.type';
 import { S3Service } from 'src/providers/storage/s3/s3.service';
 import { ChatType } from 'src/common/constants/chat.type';
+import ChatRoomService from '../chatRoom/chatRoom.service';
+import BadRequestError from 'src/common/errors/badRequestError';
+import ErrorMessage from 'src/common/constants/errorMessage.enum';
+import NotFoundError from 'src/common/errors/notFoundError';
 
 @Injectable()
 export default class ChatService {
   constructor(
     private readonly chatRepository: ChatRepository,
-    private readonly s3Service: S3Service
+    private readonly s3Service: S3Service,
+    @Inject(forwardRef(() => ChatRoomService)) private readonly chatRoomService: ChatRoomService
   ) {}
 
   async getChatsByChatRoomId(
@@ -22,7 +27,7 @@ export default class ChatService {
       this.chatRepository.findChatsByChatRoomId(options)
     ]);
 
-    const toClientListPromise = list?.map((chat) => this.convertS3PresignedUrl(chat.toClient()));
+    const toClientListPromise = list?.map((chat) => this.convertToClient(chat.toClient()));
     const toClientList = await Promise.all(toClientListPromise);
     return { totalCount, list: toClientList };
   }
@@ -30,7 +35,9 @@ export default class ChatService {
   async postChat(data: ChatCreateData): Promise<ChatToClientProperties> {
     const chatData = Chat.create(data);
     const chat = await this.chatRepository.createChat(chatData);
-    return chat.toClient();
+    const convertChat = await this.convertToClient(chat.toClient());
+
+    return convertChat;
   }
 
   async fileUpload(data: FileUploadData) {
@@ -38,15 +45,46 @@ export default class ChatService {
     const s3key = await this.s3Service.uploadFile(chatData.toS3());
     chatData.setS3Key(s3key);
     const chat = await this.chatRepository.createChat(chatData);
-    const chatWithPresignedUrl = await this.convertS3PresignedUrl(chat.toClient());
-    return chatWithPresignedUrl;
+    const convertChat = await this.convertToClient(chat.toClient());
+    return convertChat;
   }
 
-  private async convertS3PresignedUrl(chatData: ChatToClientProperties): Promise<ChatToClientProperties> {
-    const { type, content } = chatData;
-    if (type === ChatType.TEXT) return chatData;
+  async deleteChat(id: string): Promise<void> {
+    const isActive = await this.chatRoomService.isActiveByChatId(id);
+    if (!isActive) {
+      throw new BadRequestError(ErrorMessage.CHAT_ROOM_NOT_IS_ACTIVE);
+    }
+    const chat = await this.chatRepository.delete(id); //TODO. transaction
+    if (!chat) throw new NotFoundError(ErrorMessage.CHAT_NOT_FOUND_ERROR);
+    console.log(this.convertToClient(chat.toClient()));
+  }
 
-    const presignedUrl = await this.s3Service.generatePresignedUrl(content);
-    return { ...chatData, content: presignedUrl };
+  private async convertToClient(chatData: ChatToClientProperties): Promise<ChatToClientProperties> {
+    const { content, isDeletedAt, ...rest }: ChatToClientProperties = chatData;
+    let updatedContent = content;
+
+    if (isDeletedAt) {
+      rest.isDeleted = true;
+      switch (chatData.type) {
+        case 'TEXT':
+          updatedContent = '삭제된 메시지입니다.';
+          break;
+        case 'IMAGE':
+          updatedContent = '삭제된 이미지입니다.';
+          break;
+        case 'VIDEO':
+          updatedContent = '삭제된 동영상입니다.';
+          break;
+      }
+    } else {
+      rest.isDeleted = false;
+      if (chatData.type === 'TEXT') {
+        updatedContent = content;
+      } else {
+        updatedContent = await this.s3Service.generatePresignedUrl(content);
+      }
+    }
+
+    return { ...rest, content: updatedContent };
   }
 }

--- a/src/modules/chatRoom/chatRoom.repository.ts
+++ b/src/modules/chatRoom/chatRoom.repository.ts
@@ -32,8 +32,9 @@ export default class ChatRoomRepository {
     const totalCount = await this.chatRoom.count({ userIds: userId });
     return totalCount;
   }
+
   async findChatRoom(options: FindChatRoomByIdOptions): Promise<IChatRoom> {
-    const { chatRoomId, planId, chatId } = options;
+    const { chatRoomId, planId, chatId } = options || {};
     const chatRoom = await this.chatRoom
       .findOne({
         $or: [{ _id: chatRoomId }, { planId }, { chatIds: chatId }]
@@ -44,7 +45,7 @@ export default class ChatRoomRepository {
     return domainChatRoom;
   }
 
-  async findActiveChatRoomIdByUserId(userId: string): Promise<string[]> {
+  async findActiveChatRoomIdsByUserId(userId: string): Promise<string[]> {
     const chatRooms = await this.chatRoom.find({ userIds: userId, isDeletedAt: null, isActive: true }).select('_id');
     return chatRooms.map((chatRoom) => chatRoom._id.toString());
   }

--- a/src/modules/chatRoom/chatRoom.repository.ts
+++ b/src/modules/chatRoom/chatRoom.repository.ts
@@ -6,6 +6,7 @@ import ChatRoomMapper from 'src/common/domains/chatRoom/chatRoom.mapper';
 import { ChatQueryOptions } from 'src/common/types/chat/chat.type';
 import { FindChatRoomByIdOptions } from 'src/common/types/chatRoom/chatRoom.type';
 import { ChatRoom } from 'src/providers/database/mongoose/chatRoom.schema';
+import { ObjectId } from 'mongodb';
 
 @Injectable()
 export default class ChatRoomRepository {
@@ -35,9 +36,11 @@ export default class ChatRoomRepository {
 
   async findChatRoom(options: FindChatRoomByIdOptions): Promise<IChatRoom> {
     const { chatRoomId, planId, chatId } = options || {};
+    const typeChatId = new ObjectId(chatId); //NOTE. in 연산자는 string을 인식못함.
+
     const chatRoom = await this.chatRoom
       .findOne({
-        $or: [{ _id: chatRoomId }, { planId }, { chatIds: chatId }]
+        $or: [{ _id: chatRoomId }, { planId }, { chatIds: { $in: typeChatId } }]
       })
       .exec();
 

--- a/src/modules/chatRoom/chatRoom.repository.ts
+++ b/src/modules/chatRoom/chatRoom.repository.ts
@@ -35,12 +35,11 @@ export default class ChatRoomRepository {
   }
 
   async findChatRoom(options: FindChatRoomByIdOptions): Promise<IChatRoom> {
-    const { chatRoomId, planId, chatId } = options || {};
-    const typeChatId = new ObjectId(chatId); //NOTE. in 연산자는 string을 인식못함.
+    const { chatRoomId, planId } = options || {};
 
     const chatRoom = await this.chatRoom
       .findOne({
-        $or: [{ _id: chatRoomId }, { planId }, { chatIds: { $in: typeChatId } }]
+        $or: [{ _id: chatRoomId }, { planId }]
       })
       .exec();
 

--- a/src/modules/chatRoom/chatRoom.service.ts
+++ b/src/modules/chatRoom/chatRoom.service.ts
@@ -79,8 +79,6 @@ export default class ChatRoomService {
 
   async isActiveByChatId(chatId: string): Promise<boolean> {
     const isActive = (await this.getChatRoomDomain({ chatId })).getIsActive();
-
-    console.log(isActive);
     return isActive;
   }
 

--- a/src/modules/chatRoom/chatRoom.service.ts
+++ b/src/modules/chatRoom/chatRoom.service.ts
@@ -1,4 +1,4 @@
-import { HttpStatus, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { ChatCreateData, ChatQueryOptions } from 'src/common/types/chat/chat.type';
 import ChatRoomRepository from './chatRoom.repository';
 import { ChatRoomProperties, ChatRoomWithUserInfo } from 'src/common/domains/chatRoom/chatRoom.properties';
@@ -51,13 +51,13 @@ export default class ChatRoomService {
   }
 
   async getActiveChatRoomIds(userId: string): Promise<string[]> {
-    const chatRoomIds = await this.chatRoomRepository.findActiveChatRoomIdByUserId(userId);
+    const chatRoomIds = await this.chatRoomRepository.findActiveChatRoomIdsByUserId(userId);
     return chatRoomIds;
   }
 
   async getChatRoomDomain(options: FindChatRoomByIdOptions): Promise<IChatRoom> {
-    const { userId, chatRoomId } = options;
-    const chatRoom = await this.chatRoomRepository.findChatRoom({ chatRoomId: chatRoomId });
+    const { userId } = options || {};
+    const chatRoom = await this.chatRoomRepository.findChatRoom(options);
 
     if (!chatRoom) {
       throw new NotFoundError(ErrorMessage.CHAT_ROOM_NOTFOUND);
@@ -70,11 +70,18 @@ export default class ChatRoomService {
     return chatRoom;
   }
 
-  async getChatRoomById(options: FindChatRoomByIdOptions): Promise<ChatRoomWithUserInfo> {
+  async getChatRoomById(options: { userId: string; chatRoomId: string }): Promise<ChatRoomWithUserInfo> {
     const chatRoom = await this.getChatRoomDomain(options);
     const chatRoomWithUserInfo = await this.fetchAndFormatUserInfo(chatRoom.toClient());
 
     return chatRoomWithUserInfo;
+  }
+
+  async isActiveByChatId(chatId: string): Promise<boolean> {
+    const isActive = (await this.getChatRoomDomain({ chatId })).getIsActive();
+
+    console.log(isActive);
+    return isActive;
   }
 
   async getChatsByChatRoomId(options: ChatQueryOptions): Promise<{ totalCount: number; list: ChatProperties[] }> {

--- a/src/modules/chatRoom/chatRoom.service.ts
+++ b/src/modules/chatRoom/chatRoom.service.ts
@@ -77,8 +77,8 @@ export default class ChatRoomService {
     return chatRoomWithUserInfo;
   }
 
-  async isActiveByChatId(chatId: string): Promise<boolean> {
-    const isActive = (await this.getChatRoomDomain({ chatId })).getIsActive();
+  async getIsActiveById(id: string): Promise<boolean> {
+    const isActive = (await this.getChatRoomDomain({ chatRoomId: id })).getIsActive();
     return isActive;
   }
 


### PR DESCRIPTION
## 작업한 이슈 번호

- close #176 

## 작업 사항 설명

채팅 메시지 삭제

## 작업 사항

- [x] 채팅 메시지 삭제 구현
- [x] 삭제된 메시지 content 필터링해서 내보내기


## 기타

- 채팅 삭제 `DELETE` chats/:chatId
    - REQUEST
        
        ```jsx
        DELETE http://localhost:4000/chats/67a5be40d80a6a8eb3a6c3cf
        Authorization: Bearer {{DREAMER1_TOKEN}}
        ```
        
    - RESPONSE
        
        ```jsx
        HTTP/1.1 204 No Content
        X-Powered-By: Express
        Vary: Origin
        Access-Control-Allow-Credentials: true
        Date: Fri, 07 Feb 2025 08:03:28 GMT
        Connection: close
        ```
        
    - 파라미터
        
        Params
        
        - chatId: string
    - 참고사항
        - 삭제기능이 생기면서 채팅 메시지 GET 메소드 리스폰스에는 isDeleted: boolean 필드가 생김
        - 삭제가 될경우 클라이언트에는 내용을 바꿔서 전달해줌
            - 삭제된 메시지입니다.
            - 삭제된 이미지입니다.
            - 삭제된 영상입니다.
        - 서버에는 메시지 데이터 그대로 보존하고 있음
    - 에러상황
        - 해당 채팅이 없는 채팅인 경우 404에러
        - 해당 채팅방의 isActive가 false인 경우 400 에러
        - 이미 삭제된 채팅인 경우 409에러
