### PR TITLE
메이커 목록 조회 API 검색어 쿼리 수정

### DIFF
--- a/src/common/domains/user/user.domain.ts
+++ b/src/common/domains/user/user.domain.ts
@@ -175,10 +175,10 @@ export default class User implements IUser {
 
   getStats(): UserStatsToClientProperties {
     return {
-      averageRating: this.stats.averageRating,
-      totalReviews: this.stats.totalReviews,
-      totalFollows: this.stats.totalFollows,
-      totalConfirms: this.stats.totalConfirms
+      averageRating: this.stats?.averageRating ?? 0,
+      totalReviews: this.stats?.totalReviews ?? 0,
+      totalFollows: this.stats?.totalFollows ?? 0,
+      totalConfirms: this.stats?.totalConfirms ?? 0
     };
   }
 }

--- a/src/common/domains/user/user.mapper.ts
+++ b/src/common/domains/user/user.mapper.ts
@@ -25,5 +25,5 @@ export default class UserMapper {
       createdAt: this.user.createdAt,
       updatedAt: this.user.updatedAt
     });
-  } // 빈값의 객체가 나옴
+  }
 }


### PR DESCRIPTION
## 작업한 이슈 번호

- close #184 

## 작업 사항 설명

준배님이 검색어 쿼리 관련 오류 이슈를 전달하셔서 확인했는데, 디버깅 하다보니 쿼리 문제가 아니라 UserStats 값이 없는 경우 도메인에서 반환할 때 오류가 나는 문제였습니다.. 일단 임시로 UserStats가 없을 경우 0을 반환하도록 처리하고, UserStats 목데이터 추가 후에 원상복구 하겠습니다.

## 작업 사항

- [x] User Domain에서 UserStats 반환값 수정

## 기타

- 
