### PR TITLE
네이버 간편로그인 API 및 간편로그인 유저 생성 로직 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,8 @@
         "passport-google-oauth20": "^2.0.0",
         "passport-jwt": "^4.0.1",
         "passport-kakao": "^1.0.1",
+        "passport-naver": "^1.0.6",
+        "passport-oauth2": "^1.8.0",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
         "uuid": "^11.0.4"
@@ -56,6 +58,8 @@
         "@types/passport-google-oauth20": "^2.0.16",
         "@types/passport-jwt": "^4.0.1",
         "@types/passport-kakao": "^1.0.3",
+        "@types/passport-naver": "^1.0.4",
+        "@types/passport-oauth2": "^1.4.17",
         "@types/supertest": "^6.0.0",
         "@typescript-eslint/eslint-plugin": "^5.0.0",
         "@typescript-eslint/parser": "^5.0.0",
@@ -4336,6 +4340,17 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@types/passport-kakao/-/passport-kakao-1.0.3.tgz",
       "integrity": "sha512-McK5kpeiOptvjIPkiA/QS3k82//z5JM7Y3yBLMDvEA0QMMhFMcWUHhyebL1Qy+0i0n8jS+Oe4U6xAvkU22SXXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/passport": "*"
+      }
+    },
+    "node_modules/@types/passport-naver": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/passport-naver/-/passport-naver-1.0.4.tgz",
+      "integrity": "sha512-QcqccZxXUjSIkF/AdGsgWXS2jOfDuhs4ClmWht3PnFoujxoMkET3eR9KbXL8gdyOAELg1yKu8LhMnMwAbza1cw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11549,6 +11564,51 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/passport-naver": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/passport-naver/-/passport-naver-1.0.6.tgz",
+      "integrity": "sha512-5XEbJesiPVshwE0cTDvbbJrOiYSJ9VFRJTctqiZL1Xip6qOi9n7d49UesOqavLT+Ry8C7aw3zdzbmWosqHcQ/Q==",
+      "dependencies": {
+        "passport-oauth": "^1.0.0",
+        "underscore": "^1.8.3"
+      }
+    },
+    "node_modules/passport-oauth": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth/-/passport-oauth-1.0.0.tgz",
+      "integrity": "sha512-4IZNVsZbN1dkBzmEbBqUxDG8oFOIK81jqdksE3HEb/vI3ib3FMjbiZZ6MTtooyYZzmKu0BfovjvT1pdGgIq+4Q==",
+      "dependencies": {
+        "passport-oauth1": "1.x.x",
+        "passport-oauth2": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/passport-oauth1": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth1/-/passport-oauth1-1.3.0.tgz",
+      "integrity": "sha512-8T/nX4gwKTw0PjxP1xfD0QhrydQNakzeOpZ6M5Uqdgz9/a/Ag62RmJxnZQ4LkbdXGrRehQHIAHNAu11rCP46Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "oauth": "0.9.x",
+        "passport-strategy": "1.x.x",
+        "utils-merge": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
+      }
+    },
+    "node_modules/passport-oauth1/node_modules/oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==",
+      "license": "MIT"
+    },
     "node_modules/passport-oauth2": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.8.0.tgz",
@@ -13968,6 +14028,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/underscore": {
+      "version": "1.13.7",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
+      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.19.8",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
     "passport-google-oauth20": "^2.0.0",
     "passport-jwt": "^4.0.1",
     "passport-kakao": "^1.0.1",
+    "passport-naver": "^1.0.6",
+    "passport-oauth2": "^1.8.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "uuid": "^11.0.4"
@@ -71,6 +73,8 @@
     "@types/passport-google-oauth20": "^2.0.16",
     "@types/passport-jwt": "^4.0.1",
     "@types/passport-kakao": "^1.0.3",
+    "@types/passport-naver": "^1.0.4",
+    "@types/passport-oauth2": "^1.4.17",
     "@types/supertest": "^6.0.0",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",

--- a/src/common/constants/errorMessage.enum.ts
+++ b/src/common/constants/errorMessage.enum.ts
@@ -2,6 +2,7 @@ export enum ErrorMessage {
   USER_UNAUTHORIZED = '접근 권한이 없습니다.',
   USER_NOT_FOUND = '해당 유저를 찾을 수 없습니다.',
   USER_EXIST = '이미 존재하는 이메일입니다.',
+  USER_OAUTH_EXIST = '이미 존재하는 소셜 로그인 유저입니다.',
   USER_NICKNAME_EXIST = '이미 존재하는 닉네임입니다.',
   USER_UNAUTHORIZED_ID = '존재하지 않는 email 입니다.',
   USER_BAD_REQUEST_PW = '비밀번호가 일치하지 않습니다.',

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -18,6 +18,7 @@ import { Response } from 'express';
 import { AuthGuard } from '@nestjs/passport';
 import { User } from 'src/common/decorators/user.decorator';
 import { OAuthProperties } from 'src/common/types/user/user.types';
+import { OAuthProvider } from 'src/common/constants/oauth.type';
 
 @Controller('auth')
 export default class AuthController {
@@ -29,8 +30,18 @@ export default class AuthController {
   @ApiBody({ type: SignupDTO })
   @ApiCreatedResponse({ description: '회원가입 성공' })
   @ApiBadRequestResponse({ description: '이미 존재하는 닉네임 또는 이메일입니다' })
-  async signup(@Body() data: SignupDTO) {
-    return await this.service.createUser(data);
+  async signup(@Body() data: SignupDTO, @User() oauth: { provider: OAuthProvider; providerId: string }) {
+    const { user, profile } = data;
+
+    if (oauth) return await this.service.createUser({ ...oauth, ...user }, profile);
+
+    return await this.service.createUser(user, profile);
+  }
+
+  @Public()
+  @Post('tokenmaker')
+  tokenMaker() {
+    return this.service.createOAuthToken({ provider: 'KAKAO', providerId: 'q3984hf09qawefiubq2i' });
   }
 
   @Public()

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -8,6 +8,7 @@ import AuthService from './auth.service';
 import { GoogleStrategy } from './strategy/google.strategy';
 import AuthController from './auth.controller';
 import { KakaoStrategy } from './strategy/kakao.strategy';
+import { NaverStrategy } from './strategy/naver.strategy';
 
 @Module({
   imports: [
@@ -18,7 +19,7 @@ import { KakaoStrategy } from './strategy/kakao.strategy';
     UserStatsModule
   ],
   controllers: [AuthController],
-  providers: [AuthService, AuthRepository, JwtStrategy, GoogleStrategy, KakaoStrategy],
+  providers: [AuthService, AuthRepository, JwtStrategy, GoogleStrategy, KakaoStrategy, NaverStrategy],
   exports: []
 })
 export default class AuthModule {}

--- a/src/modules/auth/auth.repository.ts
+++ b/src/modules/auth/auth.repository.ts
@@ -4,7 +4,7 @@ import { DreamerProfileMapper, MakerProfileMapper } from 'src/common/domains/use
 import { IUser } from 'src/common/domains/user/user.interface';
 import UserMapper from 'src/common/domains/user/user.mapper';
 import { DreamerProfileProperties, MakerProfileProperties } from 'src/common/types/user/profile.types';
-import { SignupProperties } from 'src/common/types/user/user.types';
+import { OAuthProperties, SignupProperties } from 'src/common/types/user/user.types';
 import DBClient from 'src/providers/database/prisma/DB.client';
 
 @Injectable()
@@ -29,8 +29,8 @@ export default class AuthRepository {
     return new UserMapper(data).toDomain();
   }
 
-  async findByProviderId(providerId: string): Promise<IUser> {
-    const data = await this.db.user.findUnique({ where: { providerId } });
+  async findByProvider(providerData: OAuthProperties): Promise<IUser> {
+    const data = await this.db.user.findUnique({ where: { provider_providerId: providerData } });
 
     return new UserMapper(data).toDomain();
   }

--- a/src/modules/auth/strategy/naver.strategy.ts
+++ b/src/modules/auth/strategy/naver.strategy.ts
@@ -19,14 +19,10 @@ export class NaverStrategy extends PassportStrategy(Strategy, 'naver') {
   }
 
   async validate(accessToken: string, refreshToken: string, profile: Profile) {
-    try {
-      if (!profile) throw new InternalServerError(ErrorMessage.OAUTH_NAVER_SERVER_ERROR);
+    if (!profile) throw new InternalServerError(ErrorMessage.OAUTH_NAVER_SERVER_ERROR);
 
-      const user = { provider: OAuthProviderValues.NAVER, providerId: profile.id };
+    const user = { provider: OAuthProviderValues.NAVER, providerId: profile.id };
 
-      return user;
-    } catch (e) {
-      throw new InternalServerError('왜 오류가 날까??');
-    }
+    return user;
   }
 }

--- a/src/modules/auth/strategy/naver.strategy.ts
+++ b/src/modules/auth/strategy/naver.strategy.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { Profile, Strategy } from 'passport-naver';
+import ErrorMessage from 'src/common/constants/errorMessage.enum';
+import { OAuthProviderValues } from 'src/common/constants/oauth.type';
+import InternalServerError from 'src/common/errors/internalServerError';
+
+@Injectable()
+export class NaverStrategy extends PassportStrategy(Strategy, 'naver') {
+  constructor() {
+    super({
+      clientID: process.env.NAVER_CLIENT_ID,
+      clientSecret: process.env.NAVER_CLIENT_SECRET,
+      callbackURL: process.env.NAVER_REDIRECT,
+      authorizationURL: 'https://nid.naver.com/oauth2.0/authorize',
+      tokenURL: 'https://nid.naver.com/oauth2.0/token',
+      userProfileURL: 'https://openapi.naver.com/v1/nid/me'
+    });
+  }
+
+  async validate(accessToken: string, refreshToken: string, profile: Profile) {
+    try {
+      if (!profile) throw new InternalServerError(ErrorMessage.OAUTH_NAVER_SERVER_ERROR);
+
+      const user = { provider: OAuthProviderValues.NAVER, providerId: profile.id };
+
+      return user;
+    } catch (e) {
+      throw new InternalServerError('왜 오류가 날까??');
+    }
+  }
+}

--- a/src/providers/database/prisma/migrations/20250208182614_add_index/migration.sql
+++ b/src/providers/database/prisma/migrations/20250208182614_add_index/migration.sql
@@ -1,0 +1,32 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[provider,providerId]` on the table `User` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "User_providerId_key";
+
+-- AlterTable
+ALTER TABLE "DreamerProfile" ADD CONSTRAINT "DreamerProfile_pkey" PRIMARY KEY ("userId");
+
+-- DropIndex
+DROP INDEX "DreamerProfile_userId_key";
+
+-- AlterTable
+ALTER TABLE "MakerProfile" ADD CONSTRAINT "MakerProfile_pkey" PRIMARY KEY ("userId");
+
+-- DropIndex
+DROP INDEX "MakerProfile_userId_key";
+
+-- AlterTable
+ALTER TABLE "UserStats" ADD CONSTRAINT "UserStats_pkey" PRIMARY KEY ("userId");
+
+-- DropIndex
+DROP INDEX "UserStats_userId_key";
+
+-- CreateIndex
+CREATE INDEX "Quote_planId_idx" ON "Quote"("planId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_provider_providerId_key" ON "User"("provider", "providerId");

--- a/src/providers/database/prisma/schema.prisma
+++ b/src/providers/database/prisma/schema.prisma
@@ -25,7 +25,7 @@ model User {
   password    String?
   coconut     Int           @default(0)
   provider    OAuthProvider @default(LOCAL)
-  providerId  String?       @unique
+  providerId  String?
 
   role            Role
   receivedReviews Review[] @relation("owner")
@@ -39,6 +39,8 @@ model User {
   dreamerProfile DreamerProfile?
   makerProfile   MakerProfile?
   stats          UserStats?
+
+  @@unique([provider, providerId])
 }
 
 model DreamerProfile {
@@ -49,7 +51,7 @@ model DreamerProfile {
   serviceArea ServiceArea[]
   image       ProfileImage
   user        User          @relation(fields: [userId], references: [id], onDelete: Cascade)
-  userId      String        @unique
+  userId      String        @id
 }
 
 model MakerProfile {
@@ -63,12 +65,12 @@ model MakerProfile {
   description       String
   detailDescription String
   user              User          @relation(fields: [userId], references: [id], onDelete: Cascade)
-  userId            String        @unique
+  userId            String        @id
 }
 
 model UserStats {
   user          User   @relation(fields: [userId], references: [id], onDelete: Cascade)
-  userId        String @unique
+  userId        String @id
   averageRating Float  @default(0)
   totalReviews  Int    @default(0)
   totalFollows  Int    @default(0)
@@ -138,6 +140,8 @@ model Quote {
   makerId     String?
   isConfirmed Boolean @default(false)
   isAssigned  Boolean @default(false)
+
+  @@index([planId])
 }
 
 enum ProfileImage {


### PR DESCRIPTION
## 작업한 이슈 번호

- close #169 
- close #190 

## 작업 사항 설명

네이버 간편 로그인을 구현하고, 회원가입 요청 시 유저와 프로필 데이터와 함께 header로 OAuthToken을 받아 provider, providerId 값에 적용하도록 로직을 추가합니다.

## 작업 사항

- [x] Passport를 통한 네이버 간편 로그인 API
- [x] 회원가입 API 수정
- [x] 스키마 인덱스 추가

## 기타

- provider에 따라 providerId가 중복되는 경우가 생길 수 있어, 기존에 providerId: @unique -> @@index([provider, providerId])로 변경했습니다. 두 필드가 모두 중복인 경우를 막아줍니다.
- 추가하는 김에 다른 인덱스도 추가하고, userId를 @unique -> @id로 수정했습니다. @id가 쿼리 처리에 훨씬 빠르기 때문에 이게 더 효율적인 것 같습니다!
