### PR TITLE
메이커 관련 조회 응답 내용 수정

### DIFF
--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -67,8 +67,8 @@ export default class UserController {
 
   @Public()
   @Get('makers')
-  async getMakerList(@Query() options: GetMakerListQueryDTO) {
-    return await this.service.getMakers(options);
+  async getMakerList(@UserId() userId: string, @Query() options: GetMakerListQueryDTO) {
+    return await this.service.getMakers(options, userId);
   }
 
   @Patch('update')

--- a/src/modules/user/user.repository.ts
+++ b/src/modules/user/user.repository.ts
@@ -64,7 +64,7 @@ export default class UserRepository {
           serviceType ? { makerProfile: { serviceTypes: { has: serviceType } } } : {}
         ]
       },
-      include: { makerProfile: true, stats: true },
+      include: { makerProfile: true, stats: true, followers: { select: { dreamerId: true } } },
       orderBy: sortOption,
       take: pageSize,
       skip: pageSize * (page - 1)

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -38,10 +38,16 @@ export default class UserService {
   }
 
   async getMakers(
-    options: GetMakerListQueryDTO
+    options: GetMakerListQueryDTO,
+    userId?: string
   ): Promise<{ totalCount: number; list: Partial<MakerInfoAndProfileProperties>[] }> {
     const users = await this.repository.findMany(options);
-    const list = users.map((user) => ({ ...user.getWithMakerProfile(true), ...user.getStats() }));
+    const list = users.map((user) => ({
+      ...user.getWithMakerProfile(true),
+      isFollowed: user.isFollowed(userId),
+      ...user.getStats()
+    }));
+
     const totalCount = await this.repository.count(options);
 
     return { totalCount, list };

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -103,7 +103,7 @@ export default class UserService {
     const { totalCount, followData } = await this.follow.get(userId, options);
     const list = await Promise.all(
       followData.map(async (follow) => {
-        const profile = await this.getProfileCardData(follow.makerId, userId);
+        const profile = await this.getProfileCardData(follow.makerId, userId, true);
         return { ...follow, maker: { ...profile } };
       })
     );


### PR DESCRIPTION
## 작업한 이슈 번호

- close #194 
- close #195 

## 작업 사항 설명

작업 내용이 많지 않아, 한 PR에 함께 올립니다.
- 찜한 메이커 목록 조회 시 maker profile의 description 필드를 포함시킵니다.
- 로그인한 유저가 메이커 목록 전체 조회 요청할 때 내가 찜한 메이커인지 확인 후 isFollwed 필드에 boolean 값을 응답에 포함합니다.

## 작업 사항

- [x] 찜한 메이커 목록 조회 API 수정
- [x] 메이커 전체 목록 조회 API 수정

## 기타

- 
