### PR TITLE
포인트 차감 및 전달 구현

### DIFF
--- a/src/common/constants/errorMessage.enum.ts
+++ b/src/common/constants/errorMessage.enum.ts
@@ -10,7 +10,6 @@ export enum ErrorMessage {
   USER_FORBIDDEN_NOT_OWNER = 'Plan을 등록한 본인만 수정, 삭제할 수 있습니다. 권한을 확인해주세요.',
   USER_FORBIDDEN_NOT_MAKER = 'Maker 역할을 가진 사용자만 이 리소스에 접근할 수 있습니다. 권한을 확인해 주세요.',
   USER_FORBIDDEN_NOT_DREAMER = 'Dreamer 역할을 가진 사용자만 Plan을 생성할 수 있습니다. 권한을 확인해 주세요.',
-  USER_COCONUT_INVALID = '포인트는 0코코넛 이상이어야 합니다.',
 
   OAUTH_GOOGLE_SERVER_ERROR = '구글 프로필 정보를 가져올 수 없습니다.',
   OAUTH_KAKAO_SERVER_ERROR = '카카오 프로필 정보를 가져올 수 없습니다.',
@@ -52,6 +51,7 @@ export enum ErrorMessage {
   QUOTE_BAD_REQUEST_UPDATE_NOT_PENDING = 'PENDING 상태인 플랜의 견적만 업데이트 할 수 있습니다.',
   QUOTE_CONFLICT = '해당 플랜에 이미 견적서를 작성하셨습니다. 하나의 플랜에는 하나의 견적서만 쓸 수 있습니다.',
   QUOTE_DELETE_BAD_REQUEST_STATUS = '견적의 플랜이 PENDING 상태 일 때만 삭제할 수 있습니다.',
+  INSUFFICIENT_COCONUTS = '유저의 코코넛이 부족합니다.',
 
   PAYMENT_BAD_REQUEST = '결제 정보가 잘못되어 결제를 완료할 수 없습니다.',
   PAYMENT_AMOUNT_ERROR = '실제 결제한 금액이 결제 요청한 금액과 맞지 않습니다.',

--- a/src/common/domains/plan/plan.domain.ts
+++ b/src/common/domains/plan/plan.domain.ts
@@ -192,6 +192,11 @@ export default class Plan implements IPlan {
     return confirmedQuote?.makerId ?? null;
   }
 
+  getConfirmedPrice(): number {
+    const confirmedQuote = this.quotes?.find((quote) => quote.isConfirmed === true);
+    return confirmedQuote?.price ?? null;
+  }
+
   getId(): string {
     return this.id;
   }

--- a/src/common/domains/plan/plan.interface.ts
+++ b/src/common/domains/plan/plan.interface.ts
@@ -16,6 +16,7 @@ export default interface IPlan {
   getQuoteIds(): string[];
   getQuoteMakerIds(): string[];
   getConfirmedMakerId(): string;
+  getConfirmedPrice(): number;
   getAssigneeIds(): string[];
   getDreamerId(): string;
   getStatus(): Status;

--- a/src/common/domains/quote/quote.domain.ts
+++ b/src/common/domains/quote/quote.domain.ts
@@ -150,7 +150,7 @@ export default class Quote implements IQuote {
     return this.isConfirmed;
   }
 
-  getPrice(): number {
+  getConfirmedPrice(): number {
     return this.price;
   }
 }

--- a/src/common/domains/quote/quote.domain.ts
+++ b/src/common/domains/quote/quote.domain.ts
@@ -149,4 +149,8 @@ export default class Quote implements IQuote {
   getIsConfirmed(): boolean {
     return this.isConfirmed;
   }
+
+  getPrice(): number {
+    return this.price;
+  }
 }

--- a/src/common/domains/quote/quote.interface.ts
+++ b/src/common/domains/quote/quote.interface.ts
@@ -16,5 +16,5 @@ export default interface IQuote {
   getPlanId(): string;
   getPlanStatus(): Status;
   getIsConfirmed(): boolean;
-  getPrice(): number;
+  getConfirmedPrice(): number;
 }

--- a/src/common/domains/quote/quote.interface.ts
+++ b/src/common/domains/quote/quote.interface.ts
@@ -16,4 +16,5 @@ export default interface IQuote {
   getPlanId(): string;
   getPlanStatus(): Status;
   getIsConfirmed(): boolean;
+  getPrice(): number;
 }

--- a/src/modules/plan/plan.module.ts
+++ b/src/modules/plan/plan.module.ts
@@ -5,9 +5,10 @@ import PlanController from './plan.controller';
 import PlanRepository from './plan.repository';
 import PlanService from './plan.service';
 import ChatRoomModule from '../chatRoom/chatRoom.module';
+import { BullModule } from '@nestjs/bullmq';
 
 @Module({
-  imports: [UserModule, QuoteModule, ChatRoomModule],
+  imports: [BullModule.registerQueue({ name: 'points' }), UserModule, QuoteModule, ChatRoomModule],
   controllers: [PlanController],
   providers: [PlanRepository, PlanService],
   exports: [PlanRepository, PlanService]

--- a/src/modules/plan/plan.repository.ts
+++ b/src/modules/plan/plan.repository.ts
@@ -82,7 +82,7 @@ export default class PlanRepository {
       include: {
         dreamer: { select: { id: true, nickName: true } },
         assignees: { select: { id: true, nickName: true } },
-        quotes: { select: { id: true, makerId: true, isConfirmed: true } }
+        quotes: { select: { id: true, makerId: true, price: true, isConfirmed: true } }
       }
     });
 

--- a/src/modules/plan/plan.service.ts
+++ b/src/modules/plan/plan.service.ts
@@ -19,10 +19,14 @@ import { NotificationEventName } from 'src/common/types/notification/notificatio
 import UserService from '../user/user.service';
 import Plan from 'src/common/domains/plan/plan.domain';
 import ChatRoomService from '../chatRoom/chatRoom.service';
+import { InjectQueue } from '@nestjs/bullmq';
+import { Queue } from 'bullmq';
+import { PointEventEnum } from 'src/common/constants/pointEvent.type';
 
 @Injectable()
 export default class PlanService {
   constructor(
+    @InjectQueue('points') private readonly pointQueue: Queue,
     private readonly planRepository: PlanRepository,
     private readonly quoteService: QuoteService,
     private readonly userService: UserService,
@@ -204,6 +208,13 @@ export default class PlanService {
     const updatedPlan = await this.planRepository.update(plan);
     const planId = plan.getId();
     await this.chatRoomService.deActive({ planId });
+
+    await this.pointQueue.add('points', {
+      userId: plan.getConfirmedMakerId(),
+      event: PointEventEnum.CHARGE,
+      value: plan.getConfirmedPrice()
+    });
+
     return updatedPlan.toClient();
   }
 

--- a/src/modules/plan/plan.service.ts
+++ b/src/modules/plan/plan.service.ts
@@ -211,7 +211,7 @@ export default class PlanService {
 
     await this.pointQueue.add('points', {
       userId: plan.getConfirmedMakerId(),
-      event: PointEventEnum.CHARGE,
+      event: PointEventEnum.EARN,
       value: plan.getConfirmedPrice()
     });
 
@@ -251,6 +251,14 @@ export default class PlanService {
       await this.planRepository.updateMany({ ids: planIds, status: updateStatus });
       if (status === StatusValues.CONFIRMED) {
         await this.chatRoomService.deActive({ planIds });
+
+        plans.map(async (plan) => {
+          await this.pointQueue.add('points', {
+            userId: plan.getConfirmedMakerId(),
+            event: PointEventEnum.EARN,
+            value: plan.getConfirmedPrice()
+          });
+        });
       }
     }
   }

--- a/src/modules/quote/quote.module.ts
+++ b/src/modules/quote/quote.module.ts
@@ -4,9 +4,10 @@ import QuoteService from './quote.service';
 import QuoteRepository from './quote.repository';
 import UserModule from '../user/user.module';
 import ChatRoomModule from '../chatRoom/chatRoom.module';
+import { BullModule } from '@nestjs/bullmq';
 
 @Module({
-  imports: [UserModule, ChatRoomModule],
+  imports: [BullModule.registerQueue({ name: 'points' }), UserModule, ChatRoomModule],
   controllers: [QuoteController],
   providers: [QuoteService, QuoteRepository],
   exports: [QuoteService]

--- a/src/modules/quote/quote.service.ts
+++ b/src/modules/quote/quote.service.ts
@@ -84,6 +84,11 @@ export default class QuoteService {
       throw new ForbiddenError(ErrorMessage.QUOTE_FORBIDDEN_DREAMER);
     }
 
+    const dreamer = await this.userService.getUser(quote.getDreamerId());
+    if (dreamer.coconut < quote.getPrice()) {
+      throw new BadRequestError(ErrorMessage.INSUFFICIENT_COCONUTS);
+    }
+
     const planStatus = quote.getPlanStatus();
     if (planStatus !== StatusValues.PENDING) {
       throw new BadRequestError(ErrorMessage.QUOTE_BAD_REQUEST_UPDATE_NOT_PENDING);


### PR DESCRIPTION
## 작업한 이슈 번호

- close #201 

## 작업 사항 설명

- 플랜 견적 확정 시 견적 금액에 맞춰 Dreamer의 포인트 차감
- 플랜 완료 시 Maker에게 포인트 부여

## 작업 사항

- [x] 현재 로직에 포인트 차감 추가
- [x] 현재 로직에 포인트 전달 추가

## 기타

- 
