### PR TITLE
지역그룹별 카운팅 및 지역의 서비스 타입 그룹별 카운팅 api 구현

### DIFF
--- a/httpTest/plan.http
+++ b/httpTest/plan.http
@@ -49,4 +49,6 @@ Authorization: Bearer {{DREAMER2_TOKEN}}
 ###
 GET {{HOST_NAME}}/serviceArea-group-count
 ###
-GET {{HOST_NAME}}/tripType-group-count/SEOUL
+GET {{HOST_NAME}}/tripType-group-count/SEOU
+###
+GET {{HOST_NAME}}/groupCount?serviceArea=SEOUL

--- a/httpTest/plan.http
+++ b/httpTest/plan.http
@@ -46,3 +46,7 @@ Authorization: Bearer {{DREAMER2_TOKEN}}
 ###
 PATCH {{HOST_NAME}}/{{CONFIRMED_PLAN4}}/complete
 Authorization: Bearer {{DREAMER2_TOKEN}}
+###
+GET {{HOST_NAME}}/serviceArea-group-count
+###
+GET {{HOST_NAME}}/tripType-group-count/SEOUL

--- a/src/common/constants/groupByField.enum.ts
+++ b/src/common/constants/groupByField.enum.ts
@@ -1,0 +1,5 @@
+enum GroupByField {
+  TRIP_TYPE = 'tripType',
+  SERVICE_AREA = 'serviceArea'
+}
+export default GroupByField;

--- a/src/common/types/plan/plan.dto.ts
+++ b/src/common/types/plan/plan.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsOptional, IsDate, IsEnum, IsNotEmpty, IsInt, IsArray, Min } from 'class-validator';
+import { IsString, IsOptional, IsDate, IsEnum, IsNotEmpty, IsInt, IsArray, Min, IsIn } from 'class-validator';
 import { Transform, Type } from 'class-transformer';
 import PlanOrder from 'src/common/constants/planOrder.enum';
 import validateBooleanValue from 'src/common/utilities/validateBooleanValue';
@@ -102,7 +102,14 @@ export class PlanQueryOptionDTO {
   pageSize: number = 5;
 }
 
+export class ServiceAreaDTO {
+  @Transform(({ value }) => ServiceAreaValues[value])
+  @IsIn(Object.values(ServiceAreaValues))
+  serviceArea: ServiceArea;
+}
+
 export type GroupByCount = {
-  tripType: TripType;
+  serviceArea?: ServiceArea;
+  tripType?: TripType;
   count: number;
 }[];

--- a/src/common/types/plan/plan.dto.ts
+++ b/src/common/types/plan/plan.dto.ts
@@ -103,13 +103,8 @@ export class PlanQueryOptionDTO {
 }
 
 export class ServiceAreaDTO {
-  @Transform(({ value }) => ServiceAreaValues[value])
+  @Transform(({ value }) => ServiceAreaValues[value] ?? value)
   @IsIn(Object.values(ServiceAreaValues))
+  @IsOptional()
   serviceArea: ServiceArea;
 }
-
-export type GroupByCount = {
-  serviceArea?: ServiceArea;
-  tripType?: TripType;
-  count: number;
-}[];

--- a/src/common/types/plan/plan.type.ts
+++ b/src/common/types/plan/plan.type.ts
@@ -38,6 +38,7 @@ export interface PlanQueryOptions {
   role?: Role;
   reviewed?: boolean;
   readyToComplete?: boolean;
+  groupByField?: string;
 }
 
 export interface CreatePlanData {
@@ -69,3 +70,9 @@ export interface AssignData {
   assigneeId: string;
   isAssigned?: boolean;
 }
+
+export type GroupByCount = {
+  serviceArea?: ServiceArea;
+  tripType?: TripType;
+  count: number;
+}[];

--- a/src/modules/plan/plan.controller.ts
+++ b/src/modules/plan/plan.controller.ts
@@ -1,17 +1,4 @@
-import {
-  Body,
-  Controller,
-  Delete,
-  Get,
-  HttpCode,
-  HttpStatus,
-  Param,
-  Patch,
-  Post,
-  Query,
-  UsePipes,
-  ValidationPipe
-} from '@nestjs/common';
+import { Body, Controller, Delete, Get, HttpCode, HttpStatus, Param, Patch, Post, Query } from '@nestjs/common';
 import { UserId } from 'src/common/decorators/user.decorator';
 import { CreatePlanDataDTO, MyPlanQueryDTO, PlanQueryOptionDTO, ServiceAreaDTO } from 'src/common/types/plan/plan.dto';
 import PlanService from './plan.service';
@@ -21,11 +8,19 @@ import { QuoteToClientProperties } from 'src/common/types/quote/quoteProperties'
 import { Role } from 'src/common/decorators/roleGuard.decorator';
 import { PlanToClientProperties } from 'src/common/types/plan/plan.properties';
 import { Public } from 'src/common/decorators/public.decorator';
-import { ServiceArea } from 'src/common/constants/serviceArea.type';
 
 @Controller('plans')
 export default class PlanController {
   constructor(private readonly service: PlanService) {}
+
+  @Public()
+  @Get('groupCount')
+  async getPlanGroupCount(
+    @Query() options: ServiceAreaDTO
+  ): Promise<{ totalCount: number; groupByCount: GroupByCount }> {
+    const { totalCount, groupByCount } = await this.service.getPlanGroupCount(options.serviceArea);
+    return { totalCount, groupByCount };
+  }
 
   @Public()
   @Get('serviceArea-group-count')
@@ -36,7 +31,6 @@ export default class PlanController {
 
   @Public()
   @Get('tripType-group-count/:serviceArea')
-  @UsePipes(new ValidationPipe({ transform: true, forbidNonWhitelisted: true }))
   async getPlanTripTypeGroupCount(
     @Param() params: ServiceAreaDTO
   ): Promise<{ totalCount: number; groupByCount: GroupByCount }> {

--- a/src/modules/plan/plan.controller.ts
+++ b/src/modules/plan/plan.controller.ts
@@ -1,16 +1,48 @@
-import { Body, Controller, Delete, Get, HttpCode, HttpStatus, Param, Patch, Post, Query } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UsePipes,
+  ValidationPipe
+} from '@nestjs/common';
 import { UserId } from 'src/common/decorators/user.decorator';
-import { CreatePlanDataDTO, GroupByCount, MyPlanQueryDTO, PlanQueryOptionDTO } from 'src/common/types/plan/plan.dto';
+import { CreatePlanDataDTO, MyPlanQueryDTO, PlanQueryOptionDTO, ServiceAreaDTO } from 'src/common/types/plan/plan.dto';
 import PlanService from './plan.service';
-import { CreatePlanData } from 'src/common/types/plan/plan.type';
+import { CreatePlanData, GroupByCount } from 'src/common/types/plan/plan.type';
 import { CreateQuoteDataDTO, DreamerQuoteQueryOptionsDTO } from 'src/common/types/quote/quote.dto';
 import { QuoteToClientProperties } from 'src/common/types/quote/quoteProperties';
 import { Role } from 'src/common/decorators/roleGuard.decorator';
 import { PlanToClientProperties } from 'src/common/types/plan/plan.properties';
+import { Public } from 'src/common/decorators/public.decorator';
+import { ServiceArea } from 'src/common/constants/serviceArea.type';
 
 @Controller('plans')
 export default class PlanController {
-  constructor(private readonly planService: PlanService) {}
+  constructor(private readonly service: PlanService) {}
+
+  @Public()
+  @Get('serviceArea-group-count')
+  async getPlanServiceAreaGroupCount(): Promise<{ totalCount: number; groupByCount: GroupByCount }> {
+    const { totalCount, groupByCount } = await this.service.getPlanServiceAreaGroupCount();
+    return { totalCount, groupByCount };
+  }
+
+  @Public()
+  @Get('tripType-group-count/:serviceArea')
+  @UsePipes(new ValidationPipe({ transform: true, forbidNonWhitelisted: true }))
+  async getPlanTripTypeGroupCount(
+    @Param() params: ServiceAreaDTO
+  ): Promise<{ totalCount: number; groupByCount: GroupByCount }> {
+    const { totalCount, groupByCount } = await this.service.getPlanTripTypeGroupCount(params.serviceArea);
+    return { totalCount, groupByCount };
+  }
 
   @Get('maker')
   @Role('MAKER')
@@ -18,7 +50,7 @@ export default class PlanController {
     @UserId() userId: string,
     @Query() options: PlanQueryOptionDTO
   ): Promise<{ totalCount: number; groupByCount: GroupByCount; list: PlanToClientProperties[] }> {
-    const { totalCount, groupByCount, list } = await this.planService.getPlansByMaker(userId, options);
+    const { totalCount, groupByCount, list } = await this.service.getPlansByMaker(userId, options);
     return { totalCount, groupByCount, list };
   }
 
@@ -28,13 +60,13 @@ export default class PlanController {
     @UserId() userId: string,
     @Query() options: MyPlanQueryDTO
   ): Promise<{ totalCount: number; list: PlanToClientProperties[] }> {
-    const { totalCount, list } = await this.planService.getPlansByDreamer(userId, options);
+    const { totalCount, list } = await this.service.getPlansByDreamer(userId, options);
     return { totalCount, list };
   }
 
   @Get(':id')
   async getPlanById(@UserId() userId: string, @Param('id') id: string): Promise<PlanToClientProperties> {
-    const plan = await this.planService.getPlanById(id, userId);
+    const plan = await this.service.getPlanById(id, userId);
     return plan;
   }
 
@@ -46,7 +78,7 @@ export default class PlanController {
     @Query() options: DreamerQuoteQueryOptionsDTO
   ): Promise<{ totalCount: number; list: QuoteToClientProperties[] }> {
     const serviceOptions = { ...options, planId };
-    const { totalCount, list } = await this.planService.getQuotesByPlanId(serviceOptions, userId);
+    const { totalCount, list } = await this.service.getQuotesByPlanId(serviceOptions, userId);
     return { totalCount, list };
   }
 
@@ -55,7 +87,7 @@ export default class PlanController {
   async postPlan(@UserId() dreamerId: string, @Body() data: CreatePlanDataDTO): Promise<PlanToClientProperties> {
     const serviceData: CreatePlanData = { ...data, dreamerId };
 
-    const plan = await this.planService.postPlan(serviceData);
+    const plan = await this.service.postPlan(serviceData);
     return plan;
   }
 
@@ -66,7 +98,7 @@ export default class PlanController {
     @Param('planId') planId: string,
     @Body() data: CreateQuoteDataDTO
   ): Promise<QuoteToClientProperties> {
-    const quote = await this.planService.postQuote(data, userId, planId);
+    const quote = await this.service.postQuote(data, userId, planId);
     return quote;
   }
 
@@ -78,26 +110,26 @@ export default class PlanController {
     @Body() data: { assigneeId: string }
   ): Promise<PlanToClientProperties> {
     const options = { userId, id, assigneeId: data.assigneeId };
-    const plan = await this.planService.requestPlanAssign(options);
+    const plan = await this.service.requestPlanAssign(options);
     return plan;
   }
 
   @Patch(':id/complete')
   async completePlan(@UserId() userId: string, @Param('id') id: string): Promise<PlanToClientProperties> {
-    const plan = await this.planService.updatePlanComplete(id, userId);
+    const plan = await this.service.updatePlanComplete(id, userId);
     return plan;
   }
 
   @Delete(':id')
   @HttpCode(HttpStatus.NO_CONTENT)
   async deletePlan(@UserId() userId: string, @Param('id') id: string): Promise<void> {
-    await this.planService.deletePlan(id, userId);
+    await this.service.deletePlan(id, userId);
   }
 
   @Role('MAKER')
   @Delete(':id/assign')
   @HttpCode(HttpStatus.NO_CONTENT)
   async rejectAssignment(@UserId() userId: string, @Param('id') id: string): Promise<void> {
-    await this.planService.rejectPlanAssign({ id, assigneeId: userId });
+    await this.service.rejectPlanAssign({ id, assigneeId: userId });
   }
 }

--- a/src/modules/plan/plan.repository.ts
+++ b/src/modules/plan/plan.repository.ts
@@ -1,12 +1,12 @@
 import { Injectable } from '@nestjs/common';
+import GroupByField from 'src/common/constants/groupByField.enum';
 import PlanOrder from 'src/common/constants/planOrder.enum';
 import { RoleValues } from 'src/common/constants/role.type';
 import SortOrder from 'src/common/constants/sortOrder.enum';
 import { Status, StatusValues } from 'src/common/constants/status.type';
 import IPlan from 'src/common/domains/plan/plan.interface';
 import PlanMapper from 'src/common/domains/plan/plan.mapper';
-import { GroupByCount } from 'src/common/types/plan/plan.dto';
-import { PlanWhereConditions } from 'src/common/types/plan/plan.type';
+import { GroupByCount, PlanWhereConditions } from 'src/common/types/plan/plan.type';
 import { PlanOrderByField } from 'src/common/types/plan/plan.type';
 import { PlanQueryOptions } from 'src/common/types/plan/plan.type';
 import DBClient from 'src/providers/database/prisma/DB.client';
@@ -50,7 +50,6 @@ export default class PlanRepository {
 
   async totalCount(options: PlanQueryOptions): Promise<number> {
     const whereConditions = this.buildWhereConditions(options);
-
     const totalCount = await this.db.plan.count({
       where: whereConditions
     });
@@ -59,7 +58,8 @@ export default class PlanRepository {
   }
 
   async groupByCount(options: PlanQueryOptions): Promise<GroupByCount> {
-    const groupByField = 'tripType';
+    const groupByField =
+      options.groupByField === GroupByField.TRIP_TYPE ? GroupByField.TRIP_TYPE : GroupByField.SERVICE_AREA;
     const whereConditions = this.buildWhereConditions(options);
 
     const groupByCount = await this.db.plan.groupBy({
@@ -69,7 +69,7 @@ export default class PlanRepository {
     });
 
     const formattedGroupByCount = groupByCount.map((group) => ({
-      tripType: group.tripType,
+      [groupByField]: group[groupByField],
       count: group._count.id
     }));
 

--- a/src/modules/plan/plan.service.ts
+++ b/src/modules/plan/plan.service.ts
@@ -30,6 +30,19 @@ export default class PlanService {
     private readonly eventEmitter: EventEmitter2
   ) {}
 
+  async getPlanGroupCount(serviceArea: ServiceArea): Promise<{ totalCount: number; groupByCount: GroupByCount }> {
+    const totalCountOptions = serviceArea ? { serviceArea: [serviceArea] } : {};
+    const groupCountOptions = serviceArea
+      ? { groupByField: GroupField.TRIP_TYPE, serviceArea: [serviceArea] }
+      : { groupByField: GroupField.SERVICE_AREA };
+
+    const [totalCount, groupByCount] = await Promise.all([
+      this.repository.totalCount(totalCountOptions),
+      this.repository.groupByCount(groupCountOptions)
+    ]);
+    return { totalCount, groupByCount };
+  }
+
   async getPlanServiceAreaGroupCount(): Promise<{ totalCount: number; groupByCount: GroupByCount }> {
     const [totalCount, groupByCount] = await Promise.all([
       this.repository.totalCount({}),


### PR DESCRIPTION
## 작업한 이슈 번호

- close #202 

## 작업 사항 설명

1. 지역 그룹별 카운팅 구현
2. 지역을 쿼리로 받으면 서비스 그룹별 카운팅 구현

## 작업 사항

- [x] 지역 그룹별 카운팅 api 구현
- [x] 지역을 쿼리로 받으면 서비스 그룹별 카운팅 api 구현


## 기타

- Plan 지역별 카운팅 `GET` /plans/serviceArea-group-count
    - REQUEST
        
        ```tsx
        GET http://localhost:4000/plans/serviceArea-group-count
        ```
        
    - RESPONSE
        
        ```tsx
        HTTP/1.1 200 OK
        X-Powered-By: Express
        Vary: Origin
        Access-Control-Allow-Credentials: true
        Content-Type: application/json; charset=utf-8
        Content-Length: 107
        ETag: W/"6b-K4gpkbFVt2TjjEL/plKwpWhJE0c"
        Date: Wed, 12 Feb 2025 02:36:22 GMT
        Connection: close
        
        {
          "totalCount": 54,
          "groupByCount": [
            {
              "serviceArea": "GYEONGGI",
              "count": 14
            },
            {
              "serviceArea": "SEOUL",
              "count": 40
            }
          ]
        }
        ```
        
    - 참고사항
        - 비로그인 시에도 사용할 수 있다.
- Plan tripType별 카운팅 `GET` /plans/tripType-group-count/:serviceArea
    - REQUEST
        
        ```tsx
        GET http://localhost:4000/plans/tripType-group-count/SEOUL
        ```
        
    - RESPONSE
        
        ```tsx
        HTTP/1.1 200 OK
        X-Powered-By: Express
        Vary: Origin
        Access-Control-Allow-Credentials: true
        Content-Type: application/json; charset=utf-8
        Content-Length: 241
        ETag: W/"f1-yhgeuzcoe5cDMS9ZSZz6xvuVx04"
        Date: Wed, 12 Feb 2025 02:37:49 GMT
        Connection: close
        
        {
          "totalCount": 40,
          "groupByCount": [
            {
              "tripType": "RELAXATION",
              "count": 1
            },
            {
              "tripType": "FESTIVAL",
              "count": 3
            },
            {
              "tripType": "SHOPPING",
              "count": 4
            },
            {
              "tripType": "FOOD_TOUR",
              "count": 6
            },
            {
              "tripType": "CULTURE",
              "count": 4
            },
            {
              "tripType": "ACTIVITY",
              "count": 22
            }
          ]
        }
        ```
        
    - 파라미터
        
        Param
        
        - serviceArea: 지역명 대문자로 입력
            
            ```tsx
            export const ServiceAreaValues = {
              SEOUL: 'SEOUL',
              BUSAN: 'BUSAN',
              INCHEON: 'INCHEON',
              DAEGU: 'DAEGU',
              DAEJEON: 'DAEJEON',
              GWANGJU: 'GWANGJU',
              ULSAN: 'ULSAN',
              SEJONG: 'SEJONG',
              GYEONGGI: 'GYEONGGI',
              GANGWON: 'GANGWON',
              CHUNGBUK: 'CHUNGBUK',
              CHUNGNAM: 'CHUNGNAM',
              JEONBUK: 'JEONBUK',
              JEONNAM: 'JEONNAM',
              GYEONGBUK: 'GYEONGBUK',
              GYEONGNAM: 'GYEONGNAM',
              JEJU: 'JEJU'
            } as const;
            ```
            
    - 참고사항
        - 비로그인시 이용 가능
    - 에러상황
        - serviceArea 입력값이 틀리다면 400 에러