### PR TITLE
견적 모듈 테스트파일 구현

### DIFF
--- a/httpTest/quote.http
+++ b/httpTest/quote.http
@@ -32,3 +32,7 @@ Authorization: Bearer {{DREAMER1_TOKEN}}
 ###
 PATCH {{HOST_NAME}}/{{QUOTE3_ID}}/confirm
 Authorization: Bearer {{DREAMER1_TOKEN}}
+###
+GET http://localhost:4000/plans/16865772-f792-4bb6-8ac8-504fcb4064e3/quotes
+Authorization: Bearer {{DREAMER1_TOKEN}}
+###

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./jest-e2e.json",
-    "test:e2e:plan": "jest src/modules/plan/plan.e2e.spec.ts --detectOpenHandles --coverage"
+    "test:e2e:plan": "jest src/modules/plan/plan.e2e.spec.ts --detectOpenHandles --coverage",
+    "test:e2e:quote": "jest src/modules/quote/quote.e2e.spec.ts --detectOpenHandles --coverage"
   },
   "prisma": {
     "schema": "src/providers/database/prisma/schema.prisma"

--- a/src/common/domains/quote/quote.domain.ts
+++ b/src/common/domains/quote/quote.domain.ts
@@ -43,9 +43,6 @@ export default class Quote implements IQuote {
   }
 
   update(data: Partial<QuoteProperties>): IQuote {
-    if (this.isConfirmed === data.isConfirmed) {
-      throw new ConflictError(ErrorMessage.QUOTE_CONFLICT_IS_CONFIRMED);
-    }
     this.isConfirmed = data.isConfirmed;
     return this;
   }

--- a/src/common/types/quote/quote.dto.ts
+++ b/src/common/types/quote/quote.dto.ts
@@ -56,5 +56,8 @@ export class CreateQuoteDataDTO {
 export class UpdateQuoteDataDTO {
   @Optional()
   @IsBoolean()
+  @Transform(({ value }) => {
+    if (value === true || undefined) return value;
+  })
   isConfirmed: boolean = true;
 }

--- a/src/modules/plan/plan.e2e.spec.ts
+++ b/src/modules/plan/plan.e2e.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { HttpStatus, INestApplication, ValidationPipe } from '@nestjs/common';
 import request from 'supertest';
 import AppModule from 'src/app.module';
 import GlobalExceptionFilter from 'src/common/filters/globalExceptionFilter';
@@ -51,30 +51,28 @@ describe('PlanController (e2e)', () => {
   });
 
   describe('[GET /plans/groupCount]', () => {
-    it('should get serviceArea count', async () => {
+    it('플랜의 지역 통계', async () => {
       const { body, statusCode } = await request(app.getHttpServer()).get('/plans/groupCount');
 
-      expect(statusCode).toBe(200);
+      expect(statusCode).toBe(HttpStatus.OK);
       expect(body).toBeDefined();
     });
 
-    it('should get tripType count', async () => {
+    it('해당 지역의 tripType 통계', async () => {
       const { body, statusCode } = await request(app.getHttpServer()).get('/plans/groupCount?serviceArea=SEOUL');
 
-      expect(statusCode).toBe(200);
+      expect(statusCode).toBe(HttpStatus.OK);
       expect(body).toBeDefined();
     });
   });
 
   describe('[GET /plans/dreamer]', () => {
-    it('should get my plan List', async () => {
+    it('dreamer의 플랜 리스트', async () => {
       const { body, statusCode } = await request(app.getHttpServer())
         .get('/plans/dreamer')
         .set('authorization', `Bearer ${dreamerToken1}`);
 
-      const { list, totalCount } = body;
-
-      expect(statusCode).toBe(200);
+      expect(statusCode).toBe(HttpStatus.OK);
       expect(body).toBeDefined();
     });
 
@@ -83,7 +81,7 @@ describe('PlanController (e2e)', () => {
         .get('/plans/dreamer')
         .set('authorization', `Bearer ${makerToken}`);
 
-      expect(statusCode).toBe(403);
+      expect(statusCode).toBe(HttpStatus.FORBIDDEN);
     });
   });
 
@@ -93,7 +91,7 @@ describe('PlanController (e2e)', () => {
         .get('/plans/maker')
         .set('authorization', `Bearer ${makerToken}`);
 
-      expect(statusCode).toBe(200);
+      expect(statusCode).toBe(HttpStatus.OK);
       expect(body).toBeDefined();
     });
 
@@ -102,7 +100,7 @@ describe('PlanController (e2e)', () => {
         .get('/plans/maker')
         .set('authorization', `Bearer ${dreamerToken1}`);
 
-      expect(statusCode).toBe(403);
+      expect(statusCode).toBe(HttpStatus.FORBIDDEN);
     });
   });
 
@@ -112,7 +110,7 @@ describe('PlanController (e2e)', () => {
         .get(`/plans/${pendingPlanId}`)
         .set('authorization', `Bearer ${dreamerToken1}`);
 
-      expect(statusCode).toBe(200);
+      expect(statusCode).toBe(HttpStatus.OK);
       expect(body).toBeDefined();
     });
 
@@ -121,7 +119,7 @@ describe('PlanController (e2e)', () => {
         .get('/plans/1111111111111111111111')
         .set('authorization', `Bearer ${dreamerToken1}`);
 
-      expect(statusCode).toBe(404);
+      expect(statusCode).toBe(HttpStatus.NOT_FOUND);
     });
   });
 
@@ -141,7 +139,7 @@ describe('PlanController (e2e)', () => {
         .set('authorization', `Bearer ${dreamerToken1}`)
         .send(dto);
 
-      expect(statusCode).toBe(201);
+      expect(statusCode).toBe(HttpStatus.CREATED);
       expect(body).toBeDefined();
     });
 
@@ -151,7 +149,7 @@ describe('PlanController (e2e)', () => {
         .set('authorization', `Bearer ${makerToken}`)
         .send(dto);
 
-      expect(statusCode).toBe(403);
+      expect(statusCode).toBe(HttpStatus.FORBIDDEN);
     });
   });
 
@@ -162,7 +160,7 @@ describe('PlanController (e2e)', () => {
         .set('authorization', `Bearer ${dreamerToken1}`)
         .send({ assigneeId: makerId });
 
-      expect(statusCode).toBe(201);
+      expect(statusCode).toBe(HttpStatus.CREATED);
       expect(body).toBeDefined();
     });
 
@@ -172,7 +170,7 @@ describe('PlanController (e2e)', () => {
         .set('authorization', `Bearer ${dreamerToken2}`)
         .send({ assigneeId: makerId });
 
-      expect(statusCode).toBe(403);
+      expect(statusCode).toBe(HttpStatus.FORBIDDEN);
     });
 
     it('없는 플랜 id로 지정견적 요청하기, 404에러', async () => {
@@ -181,7 +179,7 @@ describe('PlanController (e2e)', () => {
         .set('authorization', `Bearer ${dreamerToken1}`)
         .send({ assigneeId: makerId });
 
-      expect(statusCode).toBe(404);
+      expect(statusCode).toBe(HttpStatus.NOT_FOUND);
     });
 
     it('메이커가 아닌 유저에게 지정견적 요청하기, 400에러', async () => {
@@ -190,7 +188,7 @@ describe('PlanController (e2e)', () => {
         .set('authorization', `Bearer ${dreamerToken1}`)
         .send({ assigneeId: dreamerId2 });
 
-      expect(statusCode).toBe(400);
+      expect(statusCode).toBe(HttpStatus.BAD_REQUEST);
     });
 
     it('메이커가 아닌 유저에게 지정견적 요청하기, 400에러', async () => {
@@ -199,7 +197,7 @@ describe('PlanController (e2e)', () => {
         .set('authorization', `Bearer ${dreamerToken1}`)
         .send({ assigneeId: dreamerId2 });
 
-      expect(statusCode).toBe(400);
+      expect(statusCode).toBe(HttpStatus.BAD_REQUEST);
     });
 
     it('존재하지 않는 유저의 id로 지정견적 요청하기, 400에러', async () => {
@@ -208,7 +206,7 @@ describe('PlanController (e2e)', () => {
         .set('authorization', `Bearer ${dreamerToken1}`)
         .send({ assigneeId: '11111111111' });
 
-      expect(statusCode).toBe(400);
+      expect(statusCode).toBe(HttpStatus.BAD_REQUEST);
     });
 
     it('지정견적 중복 요청하기, 409에러', async () => {
@@ -217,7 +215,7 @@ describe('PlanController (e2e)', () => {
         .set('authorization', `Bearer ${dreamerToken1}`)
         .send({ assigneeId: makerId });
 
-      expect(statusCode).toBe(409);
+      expect(statusCode).toBe(HttpStatus.CONFLICT);
     });
 
     it('PENDING이 아닌 플랜으로 지정견적 요청하기, 400에러', async () => {
@@ -226,7 +224,7 @@ describe('PlanController (e2e)', () => {
         .set('authorization', `Bearer ${dreamerToken1}`)
         .send({ assigneeId: dreamerId2 });
 
-      expect(statusCode).toBe(400);
+      expect(statusCode).toBe(HttpStatus.BAD_REQUEST);
     });
   });
 
@@ -236,7 +234,7 @@ describe('PlanController (e2e)', () => {
         .delete(`/plans/${pendingPlanId}/assign`)
         .set('authorization', `Bearer ${makerToken}`);
 
-      expect(statusCode).toBe(204);
+      expect(statusCode).toBe(HttpStatus.NO_CONTENT);
       expect(body).toEqual({});
     });
 
@@ -245,7 +243,7 @@ describe('PlanController (e2e)', () => {
         .delete(`/plans/${confirmedPlanId}/assign`)
         .set('authorization', `Bearer ${dreamerToken1}`);
 
-      expect(statusCode).toBe(403);
+      expect(statusCode).toBe(HttpStatus.FORBIDDEN);
     });
 
     it('지정견적 요청 받은적 없는 플랜의 지정견적 요청 거부하기, 400에러', async () => {
@@ -253,7 +251,7 @@ describe('PlanController (e2e)', () => {
         .delete(`/plans/${pendingPlanId}/assign`)
         .set('authorization', `Bearer ${makerToken}`);
 
-      expect(statusCode).toBe(400);
+      expect(statusCode).toBe(HttpStatus.BAD_REQUEST);
     });
 
     it('없는 플랜 id로 지정견적 요청 거부하기, 404에러', async () => {
@@ -261,7 +259,7 @@ describe('PlanController (e2e)', () => {
         .delete(`/plans/123123123123/assign`)
         .set('authorization', `Bearer ${makerToken}`);
 
-      expect(statusCode).toBe(404);
+      expect(statusCode).toBe(HttpStatus.NOT_FOUND);
     });
 
     it('PENDING이 아닌 플랜의 지정견적 요청 거부, 400에러', async () => {
@@ -269,7 +267,7 @@ describe('PlanController (e2e)', () => {
         .delete(`/plans/${confirmedPlanId}/assign`)
         .set('authorization', `Bearer ${makerToken}`);
 
-      expect(statusCode).toBe(400);
+      expect(statusCode).toBe(HttpStatus.BAD_REQUEST);
     });
   });
 
@@ -279,7 +277,7 @@ describe('PlanController (e2e)', () => {
         .patch(`/plans/${toBeCompletedPlanId}/complete`)
         .set('authorization', `Bearer ${dreamerToken1}`);
 
-      expect(statusCode).toBe(200);
+      expect(statusCode).toBe(HttpStatus.OK);
       expect(body).toBeDefined();
     });
 
@@ -288,7 +286,7 @@ describe('PlanController (e2e)', () => {
         .patch(`/plans/${pendingPlanId}/complete`)
         .set('authorization', `Bearer ${dreamerToken1}`);
 
-      expect(statusCode).toBe(400);
+      expect(statusCode).toBe(HttpStatus.BAD_REQUEST);
     });
 
     it('없는 Plan의 id로 완료 요청, 400에러', async () => {
@@ -296,7 +294,7 @@ describe('PlanController (e2e)', () => {
         .patch(`/plans/1123123123/complete`)
         .set('authorization', `Bearer ${dreamerToken1}`);
 
-      expect(statusCode).toBe(404);
+      expect(statusCode).toBe(HttpStatus.NOT_FOUND);
     });
 
     it('다른사람 플랜의 완료 요청, 403에러', async () => {
@@ -304,7 +302,7 @@ describe('PlanController (e2e)', () => {
         .patch(`/plans/${toBeCompletedPlanId}/complete`)
         .set('authorization', `Bearer ${dreamerToken2}`);
 
-      expect(statusCode).toBe(403);
+      expect(statusCode).toBe(HttpStatus.FORBIDDEN);
     });
   });
 
@@ -314,7 +312,7 @@ describe('PlanController (e2e)', () => {
         .delete(`/plans/${pendingPlanId}`)
         .set('authorization', `Bearer ${dreamerToken1}`);
 
-      expect(statusCode).toBe(204);
+      expect(statusCode).toBe(HttpStatus.NO_CONTENT);
       expect(body).toEqual({});
     });
 
@@ -323,7 +321,7 @@ describe('PlanController (e2e)', () => {
         .delete(`/plans/${confirmedPlanId}`)
         .set('authorization', `Bearer ${dreamerToken1}`);
 
-      expect(statusCode).toBe(400);
+      expect(statusCode).toBe(HttpStatus.BAD_REQUEST);
     });
 
     it('다른사람의 플랜 삭제하기 403에러', async () => {
@@ -331,7 +329,7 @@ describe('PlanController (e2e)', () => {
         .delete(`/plans/${toBeCompletedPlanId}`)
         .set('authorization', `Bearer ${dreamerToken2}`);
 
-      expect(statusCode).toBe(403);
+      expect(statusCode).toBe(HttpStatus.FORBIDDEN);
     });
   });
 });

--- a/src/modules/plan/plan.e2e.spec.ts
+++ b/src/modules/plan/plan.e2e.spec.ts
@@ -7,7 +7,7 @@ import DBClient from 'src/providers/database/prisma/DB.client';
 import { RoleValues } from 'src/common/constants/role.type';
 import AuthService from '../auth/auth.service';
 
-describe('PlanController (e2e)', () => {
+describe('Plan Test (e2e)', () => {
   let app: INestApplication;
 
   const makerId = process.env.MAKER1_ID;

--- a/src/modules/quote/quote.e2e.spec.ts
+++ b/src/modules/quote/quote.e2e.spec.ts
@@ -1,0 +1,264 @@
+import { HttpStatus, INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import AppModule from 'src/app.module';
+import GlobalExceptionFilter from 'src/common/filters/globalExceptionFilter';
+import DBClient from 'src/providers/database/prisma/DB.client';
+import AuthService from '../auth/auth.service';
+import { RoleValues } from 'src/common/constants/role.type';
+import request from 'supertest';
+
+describe('QuoteController (e2e)', () => {
+  let app: INestApplication;
+
+  const makerId1 = process.env.MAKER1_ID;
+  const makerId2 = process.env.MAKER2_ID;
+  const dreamerId1 = process.env.DREAMER1_ID;
+  const dreamerId2 = process.env.DREAMER2_ID;
+
+  const dreamer1PlanId = process.env.PENDING_PLAN_ID;
+
+  const quoteId1 = process.env.QUOTE1_ID;
+  const quoteId2 = process.env.QUOTE2_ID;
+  const toBeDeleteQuoteId = process.env.TO_BE_DELETE_QUOTE_ID;
+
+  let makerToken: string;
+  let dreamerToken1: string;
+  let dreamerToken2: string;
+  let toBeConfirmedQuoteId: string;
+
+  jest.setTimeout(100000);
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule]
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ transform: true }));
+    //.useGlobalFilters(new GlobalExceptionFilter());
+    await app.init();
+
+    const prismaDB = app.get<DBClient>(DBClient);
+    const authService = app.get<AuthService>(AuthService);
+
+    await prismaDB.seedForTestEnvironment();
+    makerToken = authService.createTokens({ userId: makerId1, role: RoleValues.MAKER }).accessToken;
+    dreamerToken1 = authService.createTokens({ userId: dreamerId1, role: RoleValues.DREAMER }).accessToken;
+    dreamerToken2 = authService.createTokens({ userId: dreamerId2, role: RoleValues.DREAMER }).accessToken;
+  });
+
+  afterAll(async () => {
+    const prismaDB = app.get<DBClient>(DBClient);
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    await prismaDB.$disconnect();
+    await app.close();
+  });
+
+  describe('[GET /plans/{planId}/quotes]', () => {
+    it('드리머가 보는 해당 플랜의 견적 리스트', async () => {
+      const { body, statusCode } = await request(app.getHttpServer())
+        .get(`/plans/${dreamer1PlanId}/quotes`)
+        .set('authorization', `Bearer ${dreamerToken1}`);
+
+      expect(statusCode).toBe(HttpStatus.OK);
+      expect(body).toBeDefined();
+    });
+
+    it('본인이 아닌 플랜의 견적을 보려고 할 때 403에러', async () => {
+      const { body, statusCode } = await request(app.getHttpServer())
+        .get(`/plans/${dreamer1PlanId}/quotes`)
+        .set('authorization', `Bearer ${dreamerToken2}`);
+
+      expect(statusCode).toBe(HttpStatus.FORBIDDEN);
+      expect(body).toBeDefined();
+    });
+
+    it('없는 플랜의 견적 리스트를 보려고 할 때 404에러', async () => {
+      const { body, statusCode } = await request(app.getHttpServer())
+        .get(`/plans/123123123123123/quotes`)
+        .set('authorization', `Bearer ${dreamerToken1}`);
+
+      expect(statusCode).toBe(HttpStatus.NOT_FOUND);
+      expect(body).toBeDefined();
+    });
+  });
+
+  describe('[GET /quotes]', () => {
+    it('메이커의 견적 리스트 보기', async () => {
+      const { body, statusCode } = await request(app.getHttpServer())
+        .get('/quotes?isSent=true')
+        .set('authorization', `Bearer ${makerToken}`);
+
+      expect(statusCode).toBe(HttpStatus.OK);
+      expect(body).toBeDefined();
+    });
+
+    it('메이커의 견적 리스트를 드리머가 요청한다면 403에러', async () => {
+      const { statusCode } = await request(app.getHttpServer())
+        .get('/quotes?isSent=true')
+        .set('authorization', `Bearer ${dreamerToken1}`);
+
+      expect(statusCode).toBe(HttpStatus.FORBIDDEN);
+    });
+
+    it('메이커의 견적 리스트에서 isSent 쿼리를 누락할 경우 400에러', async () => {
+      const { statusCode } = await request(app.getHttpServer())
+        .get('/quotes')
+        .set('authorization', `Bearer ${makerToken}`);
+
+      expect(statusCode).toBe(HttpStatus.BAD_REQUEST);
+    });
+  });
+
+  describe('[GET /quotes/{quoteId} 견적 단일조회', () => {
+    it('견적 단일 조회', async () => {
+      const { body, statusCode } = await request(app.getHttpServer())
+        .get(`/quotes/${quoteId1}`)
+        .set('authorization', `Bearer ${makerToken}`);
+
+      expect(statusCode).toBe(HttpStatus.OK);
+      expect(body).toBeDefined();
+    });
+
+    it('권한이 없는 견적 단일 조회할 경우 403 에러', async () => {
+      const { statusCode } = await request(app.getHttpServer())
+        .get(`/quotes/${quoteId2}`)
+        .set('authorization', `Bearer ${makerToken}`);
+
+      expect(statusCode).toBe(HttpStatus.FORBIDDEN);
+    });
+
+    it('없는 견적의 id로 단일 조회할 경우 404 에러', async () => {
+      const { statusCode } = await request(app.getHttpServer())
+        .get(`/quotes/123123123`)
+        .set('authorization', `Bearer ${makerToken}`);
+
+      expect(statusCode).toBe(HttpStatus.NOT_FOUND);
+    });
+  });
+
+  describe('[POST /plans/{planId}/quotes]', () => {
+    const dto = {
+      price: 150,
+      content: '저 잘해요'
+    };
+
+    it('견적 생성하기', async () => {
+      const { body, statusCode } = await request(app.getHttpServer())
+        .post(`/plans/${dreamer1PlanId}/quotes`)
+        .set('authorization', `Bearer ${makerToken}`)
+        .send(dto);
+
+      expect(statusCode).toBe(HttpStatus.CREATED);
+      expect(body).toBeDefined();
+      toBeConfirmedQuoteId = body.id;
+    });
+
+    it('없는 플랜의 id로 견적 생성할 경우 404 에러', async () => {
+      const { statusCode } = await request(app.getHttpServer())
+        .post(`/plans/123123123123123/quotes`)
+        .set('authorization', `Bearer ${makerToken}`)
+        .send(dto);
+
+      expect(statusCode).toBe(HttpStatus.NOT_FOUND);
+    });
+
+    it('이미 나의 견적이 있는 플랜에 견적 생성 요청을 할 경우 409 에러', async () => {
+      const { statusCode } = await request(app.getHttpServer())
+        .post(`/plans/${dreamer1PlanId}/quotes`)
+        .set('authorization', `Bearer ${makerToken}`)
+        .send(dto);
+
+      expect(statusCode).toBe(HttpStatus.CONFLICT);
+    });
+
+    it('메이커가 아닌경우 403에러', async () => {
+      const { statusCode } = await request(app.getHttpServer())
+        .post(`/plans/${dreamer1PlanId}/quotes`)
+        .set('authorization', `Bearer ${dreamerToken1}`)
+        .send(dto);
+
+      expect(statusCode).toBe(HttpStatus.FORBIDDEN);
+    });
+  });
+
+  describe('[PATCH /quotes/{quoteId}/confirm]', () => {
+    it('견적 확정하기', async () => {
+      const { body, statusCode } = await request(app.getHttpServer())
+        .patch(`/quotes/${toBeConfirmedQuoteId}/confirm`)
+        .set('authorization', `Bearer ${dreamerToken1}`);
+
+      expect(statusCode).toBe(HttpStatus.OK);
+      expect(body).toBeDefined();
+    });
+
+    it('견적 확정하기 요청 시 isConfirmed쿼리에 true를 제외하고 값을 넣을 경우 400에러', async () => {
+      const confirmedDto = { isConfirmed: false };
+      const { statusCode } = await request(app.getHttpServer())
+        .patch(`/quotes/${toBeConfirmedQuoteId}/confirm`)
+        .set('authorization', `Bearer ${dreamerToken1}`)
+        .send(confirmedDto);
+
+      expect(statusCode).toBe(HttpStatus.BAD_REQUEST);
+    });
+
+    it('해당 견적이 없는데 견적 확정하기를 할 경우 404에러', async () => {
+      const { statusCode } = await request(app.getHttpServer())
+        .patch(`/quotes/123123123/confirm`)
+        .set('authorization', `Bearer ${dreamerToken1}`);
+
+      expect(statusCode).toBe(HttpStatus.NOT_FOUND);
+    });
+
+    it('해당 견적의 플랜을 만든 Dreamer가 아닌데 요청하는 경우 403 에러', async () => {
+      const { statusCode } = await request(app.getHttpServer())
+        .patch(`/quotes/${toBeConfirmedQuoteId}/confirm`)
+        .set('authorization', `Bearer ${dreamerToken2}`);
+
+      expect(statusCode).toBe(HttpStatus.FORBIDDEN);
+    });
+
+    it('해당 플랜이 PENDING 상태가 아닌데 확정하기 요청을 할 경우 400 에러', async () => {
+      const { statusCode } = await request(app.getHttpServer())
+        .patch(`/quotes/${toBeConfirmedQuoteId}/confirm`)
+        .set('authorization', `Bearer ${dreamerToken1}`);
+
+      expect(statusCode).toBe(HttpStatus.BAD_REQUEST);
+    });
+  });
+
+  describe('[DELETE /quotes/{quoteId}]', () => {
+    it('견적 삭제하기', async () => {
+      const { body, statusCode } = await request(app.getHttpServer())
+        .delete(`/quotes/${toBeDeleteQuoteId}`)
+        .set('authorization', `Bearer ${makerToken}`);
+
+      expect(statusCode).toBe(HttpStatus.NO_CONTENT);
+      expect(body).toEqual({});
+    });
+
+    it('없는 견적의 id로 삭제할 경우 404 에러', async () => {
+      const { statusCode } = await request(app.getHttpServer())
+        .delete(`/quotes/123123123`)
+        .set('authorization', `Bearer ${makerToken}`);
+
+      expect(statusCode).toBe(HttpStatus.NOT_FOUND);
+    });
+
+    it('플랜의 상태가 PENDING이 아닌 견적을 삭제할 경우 400 에러', async () => {
+      const { statusCode } = await request(app.getHttpServer())
+        .delete(`/quotes/${toBeConfirmedQuoteId}`)
+        .set('authorization', `Bearer ${makerToken}`);
+
+      expect(statusCode).toBe(HttpStatus.BAD_REQUEST);
+    });
+
+    it('다른사람의 견적을 삭제할 경우 403 에러', async () => {
+      const { statusCode } = await request(app.getHttpServer())
+        .delete(`/quotes/${quoteId2}`)
+        .set('authorization', `Bearer ${makerToken}`);
+
+      expect(statusCode).toBe(HttpStatus.FORBIDDEN);
+    });
+  });
+});

--- a/src/modules/quote/quote.e2e.spec.ts
+++ b/src/modules/quote/quote.e2e.spec.ts
@@ -34,8 +34,7 @@ describe('QuoteController (e2e)', () => {
     }).compile();
 
     app = moduleFixture.createNestApplication();
-    app.useGlobalPipes(new ValidationPipe({ transform: true }));
-    //.useGlobalFilters(new GlobalExceptionFilter());
+    app.useGlobalPipes(new ValidationPipe({ transform: true })).useGlobalFilters(new GlobalExceptionFilter());
     await app.init();
 
     const prismaDB = app.get<DBClient>(DBClient);

--- a/src/modules/quote/quote.e2e.spec.ts
+++ b/src/modules/quote/quote.e2e.spec.ts
@@ -7,11 +7,10 @@ import AuthService from '../auth/auth.service';
 import { RoleValues } from 'src/common/constants/role.type';
 import request from 'supertest';
 
-describe('QuoteController (e2e)', () => {
+describe('Quote Test (e2e)', () => {
   let app: INestApplication;
 
   const makerId1 = process.env.MAKER1_ID;
-  const makerId2 = process.env.MAKER2_ID;
   const dreamerId1 = process.env.DREAMER1_ID;
   const dreamerId2 = process.env.DREAMER2_ID;
 
@@ -109,7 +108,7 @@ describe('QuoteController (e2e)', () => {
     });
   });
 
-  describe('[GET /quotes/{quoteId} 견적 단일조회', () => {
+  describe('[GET /quotes/{quoteId}', () => {
     it('견적 단일 조회', async () => {
       const { body, statusCode } = await request(app.getHttpServer())
         .get(`/quotes/${quoteId1}`)

--- a/src/modules/quote/quote.repository.ts
+++ b/src/modules/quote/quote.repository.ts
@@ -67,7 +67,10 @@ export default class QuoteRepository {
         isAssigned,
         price,
         content
-      }
+      },
+      include: {
+        maker: { select: { id: true, nickName: true } }
+      } //NOTE. 알람을 위해 추가
     });
 
     const domainQuote = new QuoteMapper(quote);

--- a/src/providers/database/prisma/DB.client.ts
+++ b/src/providers/database/prisma/DB.client.ts
@@ -1,10 +1,7 @@
 import { Injectable, OnModuleInit } from '@nestjs/common';
 import { PrismaClient } from '@prisma/client';
-import { USERS } from './mock/test.mock';
+import { QUOTES, PLANS, USERS, MAKER_PROFILES, DREAMER_PROFILES } from './mock/test.mock';
 import { HashingPassword } from 'src/common/utilities/hashingPassword';
-import { MAKER_PROFILES } from './mock/test.mock';
-import { DREAMER_PROFILES } from './mock/test.mock';
-import { PLANS } from './mock/test.mock';
 
 @Injectable()
 class DBClient extends PrismaClient implements OnModuleInit {
@@ -56,6 +53,11 @@ class DBClient extends PrismaClient implements OnModuleInit {
           }
         });
       }
+
+      await this.quote.createMany({
+        data: QUOTES,
+        skipDuplicates: true
+      });
 
       console.log('TestDatabase seeding complete!');
     } catch (error) {

--- a/src/providers/database/prisma/mock/test.mock.ts
+++ b/src/providers/database/prisma/mock/test.mock.ts
@@ -31,12 +31,31 @@ export const USERS = [
     password: '12345678',
     role: RoleValues.MAKER,
     coconut: 1000
+  },
+  {
+    id: 'ef846519-2b73-4be4-807e-f6ef1c07eb60',
+    email: 'maker2@test.com',
+    nickName: '아카시아',
+    phoneNumber: '01012341234',
+    password: '12345678',
+    role: RoleValues.MAKER,
+    coconut: 1000
   }
 ];
 export const MAKER_PROFILES = [
   {
     userId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
     image: ProfileImageValues.DEFAULT_4,
+    serviceTypes: [TripTypeValues.RELAXATION, TripTypeValues.SHOPPING],
+    serviceArea: [ServiceAreaValues.SEOUL],
+    gallery: 'https://www.instagram.com/codeit_kr/',
+    description: '여행의 꿈을 대신 이루어 드립니다!',
+    detailDescription:
+      '안녕하세요! 여행을 좋아하고, 저희 지역을 소개하고 싶은 드림 메이커입니다 :) 드리머 여러분이 꿈꾸는 여행을 대신해서 이루어 드릴게요!'
+  },
+  {
+    userId: 'ef846519-2b73-4be4-807e-f6ef1c07eb60',
+    image: ProfileImageValues.DEFAULT_3,
     serviceTypes: [TripTypeValues.RELAXATION, TripTypeValues.SHOPPING],
     serviceArea: [ServiceAreaValues.SEOUL],
     gallery: 'https://www.instagram.com/codeit_kr/',
@@ -85,6 +104,17 @@ export const PLANS = [
     dreamerId: '66885a3c-50f4-427b-8a92-3702c6976fb0'
   },
   {
+    id: '415037fb-b4da-43dc-a9e0-a68399fd5667',
+    createdAt: '2024-09-02T00:00:00.000Z', // 5개월 전
+    title: '플랜6타이틀',
+    tripDate: '2025-03-02T00:00:00.000Z',
+    tripType: TripTypeValues.FOOD_TOUR,
+    serviceArea: ServiceAreaValues.SEOUL,
+    details: '플랜6디테일',
+    status: StatusValues.PENDING,
+    dreamerId: '66885a3c-50f4-427b-8a92-3702c6976fb0'
+  },
+  {
     id: '6d201a98-1d06-4497-806a-fa123599019a',
     createdAt: '2024-09-09T00:00:00.000Z',
     title: '플랜13타이틀', //CONFIRMED
@@ -106,5 +136,38 @@ export const PLANS = [
     details: '플랜14디테일',
     status: StatusValues.CONFIRMED,
     dreamerId: '66885a3c-50f4-427b-8a92-3702c6976fb0'
+  }
+];
+
+export const QUOTES = [
+  {
+    id: '1c9cde67-ccbf-4c00-a53a-63d79f4772c3',
+    createdAt: '2024-08-25T00:00:00.000Z',
+    price: 175,
+    content: '서울 플랜1 견적',
+    planId: 'b198135d-9865-445b-a04b-742ca9939ee1',
+    makerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
+    isConfirmed: false,
+    isAssigned: true
+  },
+  {
+    id: 'f4a8cdbd-3f67-4e79-9056-8e80fe4dc7e7',
+    createdAt: '2024-08-26T00:00:00.000Z',
+    price: 165,
+    content: '서울 플랜1 견적',
+    planId: 'b198135d-9865-445b-a04b-742ca9939ee1',
+    makerId: 'ef846519-2b73-4be4-807e-f6ef1c07eb60',
+    isConfirmed: false,
+    isAssigned: false
+  },
+  {
+    id: '4cefee11-a095-4005-9158-67d3b49519ba',
+    createdAt: '2024-10-03T00:00:00.000Z',
+    price: 170,
+    content: '서울 플랜6 견적',
+    planId: '415037fb-b4da-43dc-a9e0-a68399fd5667',
+    makerId: '032d7bd4-116c-467b-9352-a14b0d494ef9',
+    isConfirmed: false,
+    isAssigned: false
   }
 ];


### PR DESCRIPTION
## 작업한 이슈 번호

- close #211 

## 작업 사항 설명

견적 모듈 테스트파일 구현

## 작업 사항

- [x] 견적 모듈 테스트파일 구현

## 기타

PASS  src/modules/quote/quote.e2e.spec.ts (32.109 s)
  QuoteController (e2e)
    [GET /plans/{planId}/quotes]
      √ 드리머가 보는 해당 플랜의 견적 리스트 (2729 ms)
      √ 본인이 아닌 플랜의 견적을 보려고 할 때 403에러 (729 ms)
      √ 없는 플랜의 견적 리스트를 보려고 할 때 404에러 (109 ms)
    [GET /quotes]
      √ 메이커의 견적 리스트 보기 (550 ms)
      √ 메이커의 견적 리스트를 드리머가 요청한다면 403에러 (24 ms)
      √ 메이커의 견적 리스트에서 isSent 쿼리를 누락할 경우 400에러 (17 ms)
    [GET /quotes/{quoteId} 견적 단일조회
      √ 견적 단일 조회 (457 ms)
      √ 권한이 없는 견적 단일 조회할 경우 403 에러 (357 ms)
      √ 없는 견적의 id로 단일 조회할 경우 404 에러 (112 ms)
    [POST /plans/{planId}/quotes]
      √ 견적 생성하기 (1515 ms)
      √ 없는 플랜의 id로 견적 생성할 경우 404 에러 (111 ms)
      √ 이미 나의 견적이 있는 플랜에 견적 생성 요청을 할 경우 409 에러 (450 ms)
      √ 메이커가 아닌경우 403에러 (20 ms)
    [PATCH /quotes/{quoteId}/confirm]
      √ 견적 확정하기 (1773 ms)
      √ 견적 확정하기 요청 시 isConfirmed쿼리에 true를 제외하고 값을 넣을 경우 400에러 (21 ms)
      √ 해당 견적이 없는데 견적 확정하기를 할 경우 404에러 (187 ms)
      √ 해당 견적의 플랜을 만든 Dreamer가 아닌데 요청하는 경우 403 에러 (437 ms)
      √ 해당 플랜이 PENDING 상태가 아닌데 확정하기 요청을 할 경우 400 에러 (608 ms)
    [DELETE /quotes/{quoteId}]
      √ 견적 삭제하기 (526 ms)
      √ 없는 견적의 id로 삭제할 경우 404 에러 (109 ms)
      √ 플랜의 상태가 PENDING이 아닌 견적을 삭제할 경우 400 에러 (353 ms)
      √ 다른사람의 견적을 삭제할 경우 403 에러 (353 ms)

----------------------------------------|---------|----------|---------|---------|----------------------------------------------------------------------------
File                                    | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
----------------------------------------|---------|----------|---------|---------|----------------------------------------------------------------------------
All files                               |   58.97 |    19.69 |   31.94 |   58.31 | 
 src                                    |     100 |      100 |     100 |     100 | 
  app.module.ts                         |     100 |      100 |     100 |     100 | 
 src/common/constants                   |     100 |      100 |     100 |     100 | 
  chat.type.ts                          |     100 |      100 |     100 |     100 | 
  errorMessage.enum.ts                  |     100 |      100 |     100 |     100 | 
  event.type.ts                         |     100 |      100 |     100 |     100 | 
  groupByField.enum.ts                  |     100 |      100 |     100 |     100 | 
  image.type.ts                         |     100 |      100 |     100 |     100 | 
  oauth.type.ts                         |     100 |      100 |     100 |     100 | 
  planOrder.enum.ts                     |     100 |      100 |     100 |     100 | 
  pointEvent.type.ts                    |     100 |      100 |     100 |     100 | 
  role.type.ts                          |     100 |      100 |     100 |     100 | 
  s3.constants.ts                       |     100 |      100 |     100 |     100 | 
  serviceArea.type.ts                   |     100 |      100 |     100 |     100 | 
  sortOrder.enum.ts                     |     100 |      100 |     100 |     100 | 
  status.type.ts                        |     100 |      100 |     100 |     100 | 
  tripType.type.ts                      |     100 |      100 |     100 |     100 | 
 src/common/decorators                  |   81.81 |        0 |      60 |      80 | 
  cookie.decorator.ts                   |      50 |        0 |       0 |      50 | 4-6
  public.decorator.ts                   |     100 |      100 |     100 |     100 | 
  role.decorator.ts                     |     100 |      100 |     100 |     100 | 
  roleGuard.decorator.ts                |     100 |      100 |     100 |     100 | 
  user.decorator.ts                     |   71.42 |      100 |      50 |   71.42 | 10-12
 src/common/domains/chat                |   10.71 |        0 |       0 |   11.53 | 
  chat.domain.ts                        |    4.54 |        0 |       0 |    4.76 | 17-84
  chat.mapper.ts                        |   33.33 |        0 |       0 |      40 | 6-11
 src/common/domains/chatRoom            |   61.76 |    33.33 |      40 |   63.63 | 
  chatRoom.domain.ts                    |   68.42 |      100 |      25 |   68.42 | 37-76
  chatRoom.mapper.ts                    |   53.33 |    33.33 |     100 |   57.14 | 15-23
 src/common/domains/follow              |   18.75 |        0 |       0 |      20 | 
  follow.domain.ts                      |      10 |      100 |       0 |      10 | 12-32
  follow.mapper.ts                      |   33.33 |        0 |       0 |      40 | 5-10                                                                       
 src/common/domains/notification        |   86.66 |      100 |   66.66 |   86.66 | 
  notification.domain.ts                |   81.81 |      100 |      50 |   81.81 | 24-28
  notification.mapper.ts                |     100 |      100 |     100 |     100 | 
 src/common/domains/payment             |      12 |        0 |       0 |      12 | 
  payment.domain.ts                     |    5.26 |      100 |       0 |    5.26 | 17-66
  payment.mapper.ts                     |   33.33 |        0 |       0 |   33.33 | 5-12
 src/common/domains/plan                |   38.09 |     6.66 |   22.58 |   41.89 | 
  plan.domain.ts                        |   31.57 |        0 |   14.28 |   35.82 | 60-201,212-225
  plan.mapper.ts                        |     100 |      100 |     100 |     100 | 
 src/common/domains/pointLog            |     100 |      100 |     100 |     100 | 
  pointLog.domain.ts                    |     100 |      100 |     100 |     100 | 
  pointLog.mapper.ts                    |     100 |      100 |     100 |     100 | 
 src/common/domains/quote               |   90.24 |    71.42 |   77.77 |      90 | 
  quote.domain.ts                       |   88.23 |    55.55 |      75 |   88.23 | 104,127,139,147
  quote.mapper.ts                       |     100 |      100 |     100 |     100 | 
 src/common/domains/review              |   13.04 |        0 |       0 |   13.63 | 
  review.domain.ts                      |    5.88 |      100 |       0 |    5.88 | 19-70
  review.mapper.ts                      |   33.33 |        0 |       0 |      40 | 5-10
 src/common/domains/user                |   38.94 |     12.5 |   22.58 |   40.21 | 
  profile.domain.ts                     |    6.25 |        0 |       0 |    6.25 | 16-46,69-111
  profile.mapper.ts                     |   33.33 |        0 |       0 |    37.5 | 5-9,21-24
  user.domain.ts                        |   56.52 |       25 |   31.25 |   57.77 | 53-60,65,79-84,122-173
  user.mapper.ts                        |      75 |        0 |   66.66 |   85.71 | 11
 src/common/domains/userStats           |   13.04 |        0 |       0 |   13.63 | 
  userStats.domain.ts                   |    5.88 |        0 |       0 |    5.88 | 15-64
  userStats.mapper.ts                   |   33.33 |        0 |       0 |      40 | 5-10
 src/common/errors                      |      90 |      100 |    62.5 |      90 | 
  badRequestError.ts                    |     100 |      100 |     100 |     100 | 
  conflictError.ts                      |     100 |      100 |     100 |     100 | 
  customError.ts                        |   83.33 |      100 |      50 |   83.33 | 14
  forbiddenError.ts                     |     100 |      100 |     100 |     100 | 
  internalServerError.ts                |      75 |      100 |       0 |      75 | 6
  notFoundError.ts                      |     100 |      100 |     100 |     100 | 
  unauthorizedError.ts                  |      75 |      100 |       0 |      75 | 6
 src/common/filters                     |   31.57 |        0 |       0 |   27.77 | 
  socketExceptionFilter.ts              |   31.57 |        0 |       0 |   27.77 | 9-27
 src/common/guards                      |      70 |    28.57 |   66.66 |   69.76 | 
  user.guard.ts                         |   79.41 |    36.36 |     100 |   82.75 | 27-31,51
  webSocket.guard.ts                    |      50 |        0 |   33.33 |   42.85 | 13-29
 src/common/pipes                       |   33.33 |        0 |       0 |   26.66 | 
  fileValidation.pipe.ts                |   33.33 |        0 |       0 |   26.66 | 7-26
 src/common/types/chat                  |     100 |      100 |     100 |     100 | 
  chat.dto.ts                           |     100 |      100 |     100 |     100 | 
 src/common/types/chatRoom              |   63.63 |      100 |       0 |   77.77 | 
  chatRoom.dto.ts                       |   63.63 |      100 |       0 |   77.77 | 5,10
 src/common/types/notification          |     100 |      100 |     100 |     100 |                                                                            
  notification.types.ts                 |     100 |      100 |     100 |     100 | 
 src/common/types/payment               |     100 |      100 |     100 |     100 | 
  payment.dto.ts                        |     100 |      100 |     100 |     100 | 
  payment.type.ts                       |     100 |      100 |     100 |     100 | 
 src/common/types/plan                  |   55.35 |        0 |       0 |   67.39 | 
  plan.dto.ts                           |   55.35 |        0 |       0 |   67.39 | 15,39,43,52-53,59-60,64,69,76,82,87,94,99,106
 src/common/types/pointLog              |   55.55 |      100 |       0 |   71.42 | 
  pointLog.dto.ts                       |   55.55 |      100 |       0 |   71.42 | 5,10
 src/common/types/quote                 |   81.25 |    66.66 |      50 |      80 | 
  quote.dto.ts                          |   81.25 |    66.66 |      50 |      80 | 15,20,25,32,36
 src/common/types/review                |   73.33 |      100 |       0 |   84.61 | 
  review.dto.ts                         |   73.33 |      100 |       0 |   84.61 | 25,30
 src/common/types/user                  |   85.91 |      100 |    12.5 |   92.42 | 
  login.dto.ts                          |     100 |      100 |     100 |     100 | 
  query.dto.ts                          |      60 |      100 |       0 |      75 | 8,12,18,22,26
  signup.dto.ts                         |     100 |      100 |     100 |     100 | 
  updateProfile.dto.ts                  |     100 |      100 |     100 |     100 | 
  updateUser.dto.ts                     |     100 |      100 |     100 |     100 | 
  user.response.dto.ts                  |     100 |      100 |     100 |     100 | 
  user.types.ts                         |     100 |      100 |     100 |     100 | 
 src/common/utilities                   |   66.66 |       25 |   66.66 |   63.63 | 
  hashingPassword.ts                    |      80 |      100 |      50 |      80 | 8
  validateBooleanValue.ts               |   57.14 |       25 |     100 |      50 | 6-8
 src/modules/auth                       |   42.13 |        0 |   13.33 |   39.59 | 
  auth.controller.ts                    |    40.9 |        0 |    7.69 |   39.68 | 34-38,44,54-66,72-73,80-96,102-103,110-124,130-133,140-154,164-178,185,192
  auth.module.ts                        |     100 |      100 |     100 |     100 | 
  auth.repository.ts                    |   36.36 |      100 |    12.5 |      30 | 15-70
  auth.service.ts                       |   31.57 |        0 |   22.22 |   29.62 | 24-81,92-111
 src/modules/auth/strategy              |    74.5 |        0 |    62.5 |      75 | 
  google.strategy.ts                    |   71.42 |        0 |      50 |   72.72 | 20-24
  jwt.strategy.ts                       |     100 |      100 |     100 |     100 | 
  kakao.strategy.ts                     |   66.66 |        0 |      50 |   66.66 | 19-24
  naver.strategy.ts                     |   71.42 |        0 |      50 |   72.72 | 22-26
 src/modules/chat                       |   41.17 |        0 |   21.73 |   38.52 | 
  chat.controller.ts                    |   66.66 |      100 |   33.33 |   61.53 | 12-14,21-22
  chat.module.ts                        |     100 |      100 |     100 |     100 | 
  chat.repository.ts                    |   38.23 |        0 |   14.28 |   35.48 | 20-73
  chat.service.ts                       |   26.02 |        0 |   16.66 |   24.24 | 28-140
 src/modules/chatRoom                   |   39.89 |     5.55 |   15.38 |   38.65 | 
  chatRoom.controller.ts                |   57.69 |      100 |      20 |   54.16 | 31-32,38-40,50-52,64-66
  chatRoom.gateway.ts                   |      48 |        0 |      25 |   45.45 | 23-38,47-48
  chatRoom.module.ts                    |     100 |      100 |     100 |     100 | 
  chatRoom.repository.ts                |   39.39 |       50 |      20 |   37.93 | 16-34,51-79
  chatRoom.service.ts                   |   22.35 |        0 |      10 |   22.36 | 27-90,101-157
 src/modules/follow                     |   54.28 |        0 |      20 |      50 | 
  follow.controller.ts                  |   83.33 |      100 |   33.33 |      80 | 13,19
  follow.module.ts                      |     100 |      100 |     100 |     100 | 
  follow.repository.ts                  |   36.84 |        0 |   14.28 |   31.25 | 12-43
  follow.service.ts                     |   41.93 |        0 |      20 |   39.28 | 23-68                                                                      
 src/modules/notification               |      64 |        0 |   28.12 |   61.36 | 
  notification.controller.ts            |   68.18 |      100 |   14.28 |      65 | 14,23,32,37,44-47
  notification.listener.ts              |     100 |      100 |     100 |     100 | 
  notification.module.ts                |     100 |      100 |     100 |     100 | 
  notification.repository.ts            |   57.89 |      100 |   33.33 |   56.25 | 14-23,33-35
  notification.service.ts               |    47.5 |        0 |   23.52 |   45.94 | 17-19,32-51,61-66
 src/modules/payment                    |   60.24 |        0 |      25 |      56 | 
  payment.controller.ts                 |   78.57 |      100 |      25 |      75 | 16,21,26
  payment.module.ts                     |     100 |      100 |     100 |     100 | 
  payment.repository.ts                 |   56.25 |      100 |      25 |      50 | 14-29
  payment.service.ts                    |   45.23 |        0 |      25 |    42.5 | 26-73
 src/modules/plan                       |   34.26 |     4.54 |   19.04 |   33.96 | 
  plan.controller.ts                    |      60 |      100 |      25 |   58.13 | 21-22,31-32,41-42,47-48,66-69,90-92,97-98,104,111
  plan.module.ts                        |     100 |      100 |     100 |     100 | 
  plan.repository.ts                    |   21.12 |        0 |   16.66 |   21.31 | 19-76,94-217
  plan.service.ts                       |    28.3 |     7.89 |   16.66 |   28.18 | 38-116,139-141,165-307
 src/modules/pointLog                   |   81.25 |      100 |      50 |   81.57 | 
  pointLog.controller.ts                |      90 |      100 |      50 |    87.5 | 13
  pointLog.module.ts                    |     100 |      100 |     100 |     100 | 
  pointLog.repository.ts                |   68.75 |      100 |      50 |   69.23 | 14-18
  pointLog.service.ts                   |   76.92 |      100 |      50 |      80 | 12-14
 src/modules/quote                      |   93.25 |    76.66 |    92.3 |    93.7 | 
  quote.controller.ts                   |     100 |      100 |     100 |     100 | 
  quote.module.ts                       |     100 |      100 |     100 |     100 | 
  quote.repository.ts                   |   96.42 |    73.33 |     100 |      98 | 138
  quote.service.ts                      |      88 |       80 |      80 |   87.69 | 64,89,124-131
 src/modules/review                     |   54.87 |        0 |   17.64 |   52.85 | 
  review.controller.ts                  |   81.25 |      100 |      25 |   78.57 | 18,27,33
  review.module.ts                      |     100 |      100 |     100 |     100 | 
  review.repository.ts                  |   26.92 |        0 |   14.28 |   22.72 | 13-65
  review.service.ts                     |   51.61 |        0 |   16.66 |   51.85 | 22-65
 src/modules/task                       |   77.77 |      100 |      25 |   73.91 | 
  task.module.ts                        |     100 |      100 |     100 |     100 | 
  tasks.service.ts                      |   68.42 |      100 |      25 |    64.7 | 18-29
 src/modules/user                       |   50.78 |      7.4 |   23.33 |    48.3 | 
  user.controller.ts                    |   70.96 |       40 |    12.5 |   68.96 | 38,50,56,65,71,81,95-98
  user.module.ts                        |     100 |      100 |     100 |     100 |                                                                            
  user.repository.ts                    |   38.46 |        0 |   27.27 |   36.11 | 24-79,103-145
  user.service.ts                       |   38.77 |        0 |   27.27 |   36.95 | 31-53,62,74-117
 src/modules/userStats                  |   51.06 |        0 |      25 |    43.9 | 
  userStats.module.ts                   |     100 |      100 |     100 |     100 | 
  userStats.repository.ts               |   53.84 |      100 |      25 |   45.45 | 12-26
  userStats.service.ts                  |   37.03 |        0 |      25 |      32 | 17-49
 src/providers/cache                    |      64 |        0 |      40 |   57.14 | 
  redis.module.ts                       |      90 |      100 |      50 |    87.5 | 13
  redis.service.ts                      |   46.66 |        0 |   33.33 |   38.46 | 13-35
 src/providers/database/mongoose        |     100 |      100 |     100 |     100 | 
  chat.schema.ts                        |     100 |      100 |     100 |     100 | 
  chatRoom.schema.ts                    |     100 |      100 |     100 |     100 | 
  notification.schema.ts                |     100 |      100 |     100 |     100 | 
  payment.schema.ts                     |     100 |      100 |     100 |     100 | 
  pointLog.schema.ts                    |     100 |      100 |     100 |     100 | 
 src/providers/database/mongoose/config |     100 |      100 |     100 |     100 | 
  mongo.config.ts                       |     100 |      100 |     100 |     100 | 
  s3.config.ts                          |     100 |      100 |     100 |     100 | 
 src/providers/database/prisma          |   97.05 |      100 |     100 |   96.77 | 
  DB.client.ts                          |   96.55 |      100 |     100 |   96.42 | 64
  prisma.module.ts                      |     100 |      100 |     100 |     100 | 
 src/providers/database/prisma/mock     |     100 |      100 |     100 |     100 | 
  test.mock.ts                          |     100 |      100 |     100 |     100 | 
  pg.module.ts                          |     100 |      100 |     100 |     100 | 
  pg.service.ts                         |   57.14 |      100 |   33.33 |      50 | 12-23
 src/providers/queue                    |   65.33 |    15.78 |   63.63 |   63.07 | 
  bullmq.module.ts                      |     100 |      100 |     100 |     100 | 
  points.processor.ts                   |   83.33 |       60 |      75 |    87.5 | 29,44-45
  userStats.processor.ts                |   38.23 |        0 |   33.33 |   34.37 | 21-60
 src/providers/storage/s3               |   52.77 |        0 |      50 |   48.38 | 
  s3.module.ts                          |     100 |      100 |     100 |     100 | 
  s3.service.ts                         |   39.28 |        0 |   33.33 |      36 | 15-51
----------------------------------------|---------|----------|---------|---------|----------------------------------------------------------------------------
Test Suites: 1 passed, 1 total
Tests:       22 passed, 22 total
Snapshots:   0 total
Time:        33.091 s
Ran all test suites matching /src\\modules\\quote\\quote.e2e.spec.ts/i.
