### PR TITLE
Auth 모듈 e2e 테스트 코드

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./jest-e2e.json",
     "test:e2e:plan": "jest src/modules/plan/plan.e2e.spec.ts --detectOpenHandles --coverage",
-    "test:e2e:quote": "jest src/modules/quote/quote.e2e.spec.ts --detectOpenHandles --coverage"
+    "test:e2e:quote": "jest src/modules/quote/quote.e2e.spec.ts --detectOpenHandles --coverage",
+    "test:e2e:auth": "jest src/modules/auth/auth.e2e.spec.ts --detectOpenHandles"
   },
   "prisma": {
     "schema": "src/providers/database/prisma/schema.prisma"

--- a/src/common/domains/user/user.domain.ts
+++ b/src/common/domains/user/user.domain.ts
@@ -49,7 +49,7 @@ export default class User implements IUser {
   }
 
   static async create(data: UserPropertiesFromDB): Promise<IUser> {
-    let hashedPassword: string;
+    let hashedPassword: string | null = null;
     if (data.password) {
       hashedPassword = await HashingPassword(data.password);
     }

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -159,10 +159,7 @@ export default class AuthController {
       throw new UnauthorizedError(ErrorMessage.REFRESH_TOKEN_NOT_FOUND);
     }
 
-    console.log('리프레시토큰 받음', refreshToken);
-
     const { accessToken, refreshToken: newRefreshToken } = this.service.createNewToken(refreshToken);
-    console.log('토큰 재발급 완료', accessToken);
 
     res.cookie('refreshToken', newRefreshToken, {
       path: '/user/token/refresh',

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -39,12 +39,6 @@ export default class AuthController {
   }
 
   @Public()
-  @Post('tokenmaker')
-  tokenMaker() {
-    return this.service.createOAuthToken({ provider: 'KAKAO', providerId: 'q3984hf09qawefiubq2i' });
-  }
-
-  @Public()
   @Post('login')
   @ApiOperation({ summary: '로그인', description: '이메일과 비밀번호로 유저 로그인 요청을 보냅니다' })
   @ApiBody({ type: LoginDTO })
@@ -165,7 +159,10 @@ export default class AuthController {
       throw new UnauthorizedError(ErrorMessage.REFRESH_TOKEN_NOT_FOUND);
     }
 
+    console.log('리프레시토큰 받음', refreshToken);
+
     const { accessToken, refreshToken: newRefreshToken } = this.service.createNewToken(refreshToken);
+    console.log('토큰 재발급 완료', accessToken);
 
     res.cookie('refreshToken', newRefreshToken, {
       path: '/user/token/refresh',

--- a/src/modules/auth/auth.e2e.spec.ts
+++ b/src/modules/auth/auth.e2e.spec.ts
@@ -1,0 +1,228 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpStatus, INestApplication, ValidationPipe } from '@nestjs/common';
+import request from 'supertest';
+import AppModule from 'src/app.module';
+import GlobalExceptionFilter from 'src/common/filters/globalExceptionFilter';
+import DBClient from 'src/providers/database/prisma/DB.client';
+import { RoleValues } from 'src/common/constants/role.type';
+import AuthService from '../auth/auth.service';
+import { OAuthProviderValues } from 'src/common/constants/oauth.type';
+import { ProfileImageValues } from 'src/common/constants/image.type';
+import { TripTypeValues } from 'src/common/constants/tripType.type';
+import { ServiceAreaValues } from 'src/common/constants/serviceArea.type';
+import cookieParser from 'cookie-parser';
+
+describe('Auth Test (e2e)', () => {
+  let app: INestApplication;
+
+  const existId = process.env.DREAMER1_ID;
+  const existEmail = process.env.DREAMER1_EMAIL;
+  const existNickName = process.env.DREAMER1_NICKNAME;
+  const existPassword = process.env.DREAMER1_PASSWORD;
+
+  let refreshToken: string;
+  let googleToken: string;
+  let googleToken2: string;
+
+  jest.setTimeout(100000);
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule]
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ transform: true })).useGlobalFilters(new GlobalExceptionFilter());
+    app.use(cookieParser());
+    await app.init();
+
+    const prismaDB = app.get<DBClient>(DBClient);
+    const authService = app.get<AuthService>(AuthService);
+
+    await prismaDB.seedForTestEnvironment();
+    refreshToken = authService.createTokens({ userId: existId, role: RoleValues.DREAMER }).refreshToken;
+    googleToken = authService.createOAuthToken({ provider: OAuthProviderValues.GOOGLE, providerId: '1' }).OAuthToken;
+    googleToken2 = authService.createOAuthToken({
+      provider: OAuthProviderValues.GOOGLE,
+      providerId: process.env.OAUTH_GOOGLE_PROVIDER_ID
+    }).OAuthToken;
+  });
+
+  afterAll(async () => {
+    const prismaDB = app.get<DBClient>(DBClient);
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    await prismaDB.$disconnect();
+    await app.close();
+  });
+
+  describe('[POST /auth/signup]', () => {
+    let email = 'e2e@test.com';
+    let nickName = '1';
+    const dto = {
+      user: {
+        role: RoleValues.DREAMER,
+        nickName,
+        email,
+        password: '123456789',
+        phoneNumber: '01012345678'
+      },
+      profile: {
+        image: ProfileImageValues.DEFAULT_1,
+        tripTypes: [TripTypeValues.ACTIVITY],
+        serviceArea: [ServiceAreaValues.SEOUL]
+      }
+    };
+    const socialDto = {
+      user: {
+        role: RoleValues.DREAMER,
+        nickName: '2',
+        phoneNumber: '01012345678'
+      },
+      profile: {
+        image: ProfileImageValues.DEFAULT_1,
+        tripTypes: [TripTypeValues.ACTIVITY],
+        serviceArea: [ServiceAreaValues.SEOUL]
+      }
+    };
+
+    it('새로운 유저 생성', async () => {
+      const { statusCode } = await request(app.getHttpServer()).post('/auth/signup').send(dto);
+
+      expect(statusCode).toBe(HttpStatus.CREATED);
+    });
+
+    it('새로운 소셜 로그인 유저 생성', async () => {
+      const { statusCode } = await request(app.getHttpServer())
+        .post('/auth/signup')
+        .set('authorization', `Bearer ${googleToken}`)
+        .send(socialDto);
+
+      expect(statusCode).toBe(HttpStatus.CREATED);
+    });
+
+    it('기존 소셜 로그인 유저인 경우 400에러', async () => {
+      const { statusCode } = await request(app.getHttpServer())
+        .post('/auth/signup')
+        .send(socialDto)
+        .set('authorization', `Bearer ${googleToken2}`);
+
+      expect(statusCode).toBe(HttpStatus.BAD_REQUEST);
+    });
+
+    it('이메일이 중복인 경우 400에러', async () => {
+      email = existEmail;
+      const { statusCode } = await request(app.getHttpServer()).post('/auth/signup').send(dto);
+
+      expect(statusCode).toBe(HttpStatus.BAD_REQUEST);
+    });
+
+    it('닉네임이 중복인 경우 400에러', async () => {
+      email = 'e2e@test.com';
+      nickName = existNickName;
+      const { statusCode } = await request(app.getHttpServer()).post('/auth/signup').send(dto);
+
+      expect(statusCode).toBe(HttpStatus.BAD_REQUEST);
+    });
+  });
+
+  describe('[POST /auth/login]', () => {
+    const dto = { email: existEmail, password: existPassword };
+
+    it('유저 로그인 요청', async () => {
+      const { body, statusCode } = await request(app.getHttpServer()).post('/auth/login').send(dto);
+
+      expect(statusCode).toBe(HttpStatus.CREATED);
+      expect(body).toBeDefined();
+    });
+
+    it('존재하지 않는 ID인 경우 400에러', async () => {
+      const { statusCode } = await request(app.getHttpServer())
+        .post('/auth/login')
+        .send({ ...dto, email: 'wrong' });
+
+      expect(statusCode).toBe(HttpStatus.BAD_REQUEST);
+    });
+
+    it('잘못된 비밀번호인 경우 400에러', async () => {
+      const { statusCode } = await request(app.getHttpServer())
+        .post('/auth/login')
+        .send({ ...dto, password: 'wrong' });
+
+      expect(statusCode).toBe(HttpStatus.BAD_REQUEST);
+    });
+  });
+
+  describe('[GET /auth/google]', () => {
+    it('구글 로그인 리다이렉트 주소를 반환', async () => {
+      const { body, statusCode } = await request(app.getHttpServer()).get('/auth/google');
+
+      expect(statusCode).toBe(HttpStatus.OK);
+      expect(body).toBeDefined();
+    });
+  });
+
+  describe('[GET /auth/kakao]', () => {
+    it('카카오 로그인 리다이렉트 주소를 반환', async () => {
+      const { body, statusCode } = await request(app.getHttpServer()).get('/auth/kakao');
+
+      expect(statusCode).toBe(HttpStatus.OK);
+      expect(body).toBeDefined();
+    });
+  });
+
+  describe('[GET /auth/naver]', () => {
+    it('네이버 로그인 리다이렉트 주소를 반환', async () => {
+      const { body, statusCode } = await request(app.getHttpServer()).get('/auth/naver');
+
+      expect(statusCode).toBe(HttpStatus.OK);
+      expect(body).toBeDefined();
+    });
+  });
+
+  describe('[POST /auth/refresh/token]', () => {
+    it('리프레시토큰을 통해 토큰 재발급', async () => {
+      const { body, statusCode } = await request(app.getHttpServer())
+        .post('/auth/refresh/token')
+        .set('Cookie', [`refreshToken=${refreshToken}`]);
+
+      expect(statusCode).toBe(HttpStatus.CREATED);
+      expect(body).toBeDefined();
+    });
+
+    it('리프레시토큰이 없는 경우 401에러', async () => {
+      const { statusCode } = await request(app.getHttpServer()).post(`/auth/refresh/token`);
+
+      expect(statusCode).toBe(HttpStatus.UNAUTHORIZED);
+    });
+
+    it('리프레시토큰이 유효하지 않은 경우 401에러', async () => {
+      const { statusCode } = await request(app.getHttpServer())
+        .post(`/auth/refresh/token`)
+        .set('Cookie', `refreshToken=111`);
+
+      expect(statusCode).toBe(HttpStatus.UNAUTHORIZED);
+    });
+  });
+
+  describe('[POST /auth/check/email]', () => {
+    it('이메일 중복 검사', async () => {
+      const { body, statusCode } = await request(app.getHttpServer())
+        .post(`/auth/check/email`)
+        .send({ email: '1@test.com' });
+
+      expect(statusCode).toBe(HttpStatus.OK);
+      expect(body).toBeTruthy();
+    });
+  });
+
+  describe('[POST /auth/check/nickname]', () => {
+    it('닉네임 중복 검사', async () => {
+      const { body, statusCode } = await request(app.getHttpServer())
+        .post(`/auth/check/nickname`)
+        .send({ nickName: '0' });
+
+      expect(statusCode).toBe(HttpStatus.OK);
+      expect(body).toBeTruthy();
+    });
+  });
+});

--- a/src/providers/database/prisma/DB.client.ts
+++ b/src/providers/database/prisma/DB.client.ts
@@ -13,7 +13,7 @@ class DBClient extends PrismaClient implements OnModuleInit {
     const users = await Promise.all(
       USERS.map(async (user) => ({
         ...user,
-        password: await HashingPassword(user.password)
+        password: user.password ? await HashingPassword(user.password) : null
       }))
     );
 

--- a/src/providers/database/prisma/mock/test.mock.ts
+++ b/src/providers/database/prisma/mock/test.mock.ts
@@ -1,4 +1,5 @@
 import { ProfileImageValues } from 'src/common/constants/image.type';
+import { OAuthProviderValues } from 'src/common/constants/oauth.type';
 import { RoleValues } from 'src/common/constants/role.type';
 import { ServiceAreaValues } from 'src/common/constants/serviceArea.type';
 import { StatusValues } from 'src/common/constants/status.type';
@@ -40,6 +41,15 @@ export const USERS = [
     password: '12345678',
     role: RoleValues.MAKER,
     coconut: 1000
+  },
+  {
+    id: 'ad3436a3-f163-4af7-8892-3a19f61894d0',
+    nickName: '구글메이커',
+    phoneNumber: '01012341234',
+    role: RoleValues.MAKER,
+    coconut: 1000,
+    provider: OAuthProviderValues.GOOGLE,
+    providerId: '1234'
   }
 ];
 export const MAKER_PROFILES = [


### PR DESCRIPTION
## 작업한 이슈 번호

- close #217

## 작업 사항 설명

Auth 모듈 테스트 코드 구현

## 작업 사항

- [x] Auth 모듈 테스트 코드 구현

## 기타

- controller의 coverage가 높지 않은 이유는 auth.controller에 만든 소셜 로그인의 콜백 API의 경우 브라우저에서 구글 등에 직접 로그인 후 토큰을 받아서 처리하기 때문에 직접 테스트가 불가하기 때문입니다. 추후에 모킹해서 테스트 추가하겠습니다~!

| File | $ Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s |
|--|--|--|--|--|--|
|src/modules/auth                       |   83.33 |    53.33 |   79.31 |   82.89 |      |                                                         
|  auth.controller.ts                    |   77.27 |       40 |      75 |   76.19 | 74-90,104-118,134-148  |                  
|  auth.module.ts                        |     100 |      100 |     100 |     100 |        |                                                       
|  auth.repository.ts                    |   81.81 |      100 |      75 |      80 | 27-29,58-70   |                                                
|  auth.service.ts                       |   86.66 |       60 |   88.88 |   87.71 | 41,52-53,65,79-82 |