### PR TITLE
채팅방 모듈 테스트 파일 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "test:e2e": "jest --config ./jest-e2e.json",
     "test:e2e:plan": "jest src/modules/plan/plan.e2e.spec.ts --detectOpenHandles --coverage",
     "test:e2e:quote": "jest src/modules/quote/quote.e2e.spec.ts --detectOpenHandles --coverage",
-    "test:e2e:auth": "jest src/modules/auth/auth.e2e.spec.ts --detectOpenHandles"
+    "test:e2e:auth": "jest src/modules/auth/auth.e2e.spec.ts --detectOpenHandles",
+    "test:e2e:chatRoom": "jest src/modules/chatRoom/chatRoom.e2e.spec.ts --detectOpenHandles --coverage"
   },
   "prisma": {
     "schema": "src/providers/database/prisma/schema.prisma"

--- a/src/modules/chatRoom/chatRoom.e2e.spec.ts
+++ b/src/modules/chatRoom/chatRoom.e2e.spec.ts
@@ -1,0 +1,94 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpStatus, INestApplication, ValidationPipe } from '@nestjs/common';
+import request from 'supertest';
+import AppModule from 'src/app.module';
+import GlobalExceptionFilter from 'src/common/filters/globalExceptionFilter';
+import DBClient from 'src/providers/database/prisma/DB.client';
+import { RoleValues } from 'src/common/constants/role.type';
+import AuthService from '../auth/auth.service';
+import { seed } from 'src/providers/database/mongoose/mongoose.seed';
+
+describe('ChatRoom Test (e2e)', () => {
+  let app: INestApplication;
+
+  const makerId = process.env.MAKER1_ID;
+
+  const dreamerId1 = process.env.DREAMER1_ID;
+  const dreamerId2 = process.env.DREAMER2_ID;
+
+  let makerToken: string;
+  let dreamerToken1: string;
+  let dreamerToken2: string;
+  let chatRoomId: string;
+
+  jest.setTimeout(100000);
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule]
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ transform: true })).useGlobalFilters(new GlobalExceptionFilter());
+    await app.init();
+
+    const authService = app.get<AuthService>(AuthService);
+    await seed();
+
+    makerToken = authService.createTokens({ userId: makerId, role: RoleValues.MAKER }).accessToken;
+    dreamerToken1 = authService.createTokens({ userId: dreamerId1, role: RoleValues.DREAMER }).accessToken;
+    dreamerToken2 = authService.createTokens({ userId: dreamerId2, role: RoleValues.DREAMER }).accessToken;
+  });
+
+  afterAll(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    await app.close();
+  });
+
+  describe('[GET /chatRooms]', () => {
+    it('나의 채팅방 목록 조회', async () => {
+      const { body, statusCode } = await request(app.getHttpServer())
+        .get('/chatRooms')
+        .set('authorization', `Bearer ${dreamerToken1}`);
+
+      chatRoomId = body.list[0].id;
+      expect(statusCode).toBe(HttpStatus.OK);
+      expect(body).toBeDefined();
+    });
+
+    it('나의 채팅방 목록 조회, 유효한 토큰이 오지 않을 경우 401에러', async () => {
+      const { statusCode } = await request(app.getHttpServer())
+        .get('/chatRooms')
+        .set('authorization', `Bearer 123123123123`);
+
+      expect(statusCode).toBe(HttpStatus.UNAUTHORIZED);
+    });
+  });
+
+  describe('[GET /chatRooms/{chatRoomId}]', () => {
+    it('채팅방 단일조회', async () => {
+      const { body, statusCode } = await request(app.getHttpServer())
+        .get(`/chatRooms/${chatRoomId}`)
+        .set('authorization', `Bearer ${dreamerToken1}`);
+
+      expect(statusCode).toBe(HttpStatus.OK);
+      expect(body).toBeDefined();
+    });
+
+    it('채팅방 단일조회, 유효한 토큰이 아닌 경우 401에러', async () => {
+      const { statusCode } = await request(app.getHttpServer())
+        .get(`/chatRooms/${chatRoomId}`)
+        .set('authorization', `Bearer 123123`);
+
+      expect(statusCode).toBe(HttpStatus.UNAUTHORIZED);
+    });
+
+    it('채팅방 단일조회, 채팅방에 대한 권한이 없을 경우 403에러', async () => {
+      const { statusCode } = await request(app.getHttpServer())
+        .get(`/chatRooms/${chatRoomId}`)
+        .set('authorization', `Bearer ${dreamerToken2}`);
+
+      expect(statusCode).toBe(HttpStatus.FORBIDDEN);
+    });
+  });
+});


### PR DESCRIPTION
## 작업한 이슈 번호

- close #213 

## 작업 사항 설명


## 작업 사항

- [x] 채팅방 모듈 테스트 파일 구현


## 기타

PASS  src/modules/chatRoom/chatRoom.e2e.spec.ts (17.138 s)
  ChatRoom Test (e2e)
    [GET /chatRooms]
      √ 나의 채팅방 목록 조회 (1301 ms)
      √ 나의 채팅방 목록 조회, 유효한 토큰이 오지 않을 경우 401에러 (18 ms)
    [GET /chatRooms/{chatRoomId}]
      √ 채팅방 단일조회 (388 ms)
      √ 채팅방 단일조회, 유효한 토큰이 아닌 경우 401에러 (14 ms)
      √ 채팅방 단일조회, 채팅방에 대한 권한이 없을 경우 403에러 (35 ms)

----------------------------------------|---------|----------|---------|---------|-----------------------------------------------------------------------
File                                    | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
----------------------------------------|---------|----------|---------|---------|-----------------------------------------------------------------------
All files                               |   51.74 |    10.37 |   20.93 |   50.99 | 
 src                                    |     100 |      100 |     100 |     100 | 
  app.module.ts                         |     100 |      100 |     100 |     100 | 
 src/common/constants                   |     100 |      100 |     100 |     100 | 
  chat.type.ts                          |     100 |      100 |     100 |     100 | 
  errorMessage.enum.ts                  |     100 |      100 |     100 |     100 | 
  event.type.ts                         |     100 |      100 |     100 |     100 | 
  groupByField.enum.ts                  |     100 |      100 |     100 |     100 | 
  image.type.ts                         |     100 |      100 |     100 |     100 | 
  oauth.type.ts                         |     100 |      100 |     100 |     100 | 
  planOrder.enum.ts                     |     100 |      100 |     100 |     100 | 
  pointEvent.type.ts                    |     100 |      100 |     100 |     100 | 
  role.type.ts                          |     100 |      100 |     100 |     100 | 
  s3.constants.ts                       |     100 |      100 |     100 |     100 | 
  serviceArea.type.ts                   |     100 |      100 |     100 |     100 | 
  sortOrder.enum.ts                     |     100 |      100 |     100 |     100 | 
  status.type.ts                        |     100 |      100 |     100 |     100 | 
  tripType.type.ts                      |     100 |      100 |     100 |     100 | 
 src/common/decorators                  |   72.72 |        0 |      40 |      70 | 
  cookie.decorator.ts                   |      50 |        0 |       0 |      50 | 4-6
  public.decorator.ts                   |     100 |      100 |     100 |     100 |                                                                       
  role.decorator.ts                     |      50 |      100 |       0 |      50 | 4-6
  roleGuard.decorator.ts                |     100 |      100 |     100 |     100 | 
  user.decorator.ts                     |   71.42 |      100 |      50 |   71.42 | 10-12
 src/common/domains/chat                |   10.71 |        0 |       0 |   11.53 | 
  chat.domain.ts                        |    4.54 |        0 |       0 |    4.76 | 17-84
  chat.mapper.ts                        |   33.33 |        0 |       0 |      40 | 6-11
 src/common/domains/chatRoom            |    64.7 |    33.33 |      50 |   66.66 | 
  chatRoom.domain.ts                    |   73.68 |      100 |    37.5 |   73.68 | 33-37,64-68,76
  chatRoom.mapper.ts                    |   53.33 |    33.33 |     100 |   57.14 | 15-23
 src/common/domains/follow              |   18.75 |        0 |       0 |      20 | 
  follow.domain.ts                      |      10 |      100 |       0 |      10 | 12-32
  follow.mapper.ts                      |   33.33 |        0 |       0 |      40 | 5-10
 src/common/domains/notification        |      20 |      100 |       0 |      20 | 
  notification.domain.ts                |    9.09 |      100 |       0 |    9.09 | 14-32
  notification.mapper.ts                |      50 |      100 |       0 |      50 | 5-8
 src/common/domains/payment             |      12 |        0 |       0 |      12 | 
  payment.domain.ts                     |    5.26 |      100 |       0 |    5.26 | 17-66
  payment.mapper.ts                     |   33.33 |        0 |       0 |   33.33 | 5-12
 src/common/domains/plan                |   10.71 |        0 |       0 |   12.16 | 
  plan.domain.ts                        |    9.21 |        0 |       0 |   10.44 | 43-229
  plan.mapper.ts                        |      25 |        0 |       0 |   28.57 | 7-35
 src/common/domains/pointLog            |   23.07 |      100 |       0 |   23.07 | 
  pointLog.domain.ts                    |   11.11 |      100 |       0 |   11.11 | 14-27
  pointLog.mapper.ts                    |      50 |      100 |       0 |      50 | 5-8
 src/common/domains/quote               |   12.19 |        0 |       0 |    12.5 | 
  quote.domain.ts                       |    8.82 |        0 |       0 |    8.82 | 27-151
  quote.mapper.ts                       |   28.57 |        0 |       0 |   33.33 | 6-13
 src/common/domains/review              |   13.04 |        0 |       0 |   13.63 | 
  review.domain.ts                      |    5.88 |      100 |       0 |    5.88 | 19-70
  review.mapper.ts                      |   33.33 |        0 |       0 |      40 | 5-10
 src/common/domains/user                |   54.16 |      2.5 |    38.7 |   55.91 | 
  profile.domain.ts                     |   59.37 |        0 |      50 |   59.37 | 25-38,81-100
  profile.mapper.ts                     |   88.88 |        0 |     100 |     100 | 8
  user.domain.ts                        |   40.42 |        5 |    12.5 |    41.3 | 52-88,113-173
  user.mapper.ts                        |      75 |        0 |   66.66 |   85.71 | 11
 src/common/domains/userStats           |   13.04 |        0 |       0 |   13.63 | 
  userStats.domain.ts                   |    5.88 |        0 |       0 |    5.88 | 15-64
  userStats.mapper.ts                   |   33.33 |        0 |       0 |      40 | 5-10
 src/common/errors                      |   83.33 |      100 |    37.5 |   83.33 | 
  badRequestError.ts                    |      75 |      100 |       0 |      75 | 6
  conflictError.ts                      |      75 |      100 |       0 |      75 | 6
  customError.ts                        |   83.33 |      100 |      50 |   83.33 | 14
  forbiddenError.ts                     |     100 |      100 |     100 |     100 | 
  internalServerError.ts                |      75 |      100 |       0 |      75 | 6
  notFoundError.ts                      |      75 |      100 |       0 |      75 | 6
  unauthorizedError.ts                  |     100 |      100 |     100 |     100 |                                                                       
 src/common/filters                     |      55 |     8.33 |      50 |   52.63 | 
  globalExceptionFilter.ts              |   76.19 |    16.66 |     100 |      75 | 19-24
  socketExceptionFilter.ts              |   31.57 |        0 |       0 |   27.77 | 9-27
 src/common/guards                      |      66 |    42.85 |   66.66 |   65.11 | 
  user.guard.ts                         |   73.52 |    54.54 |     100 |   75.86 | 27-31,42-46
  webSocket.guard.ts                    |      50 |        0 |   33.33 |   42.85 | 13-29
 src/common/pipes                       |   33.33 |        0 |       0 |   26.66 | 
  fileValidation.pipe.ts                |   33.33 |        0 |       0 |   26.66 | 7-26
 src/common/types/chat                  |     100 |      100 |     100 |     100 | 
  chat.dto.ts                           |     100 |      100 |     100 |     100 | 
 src/common/types/chatRoom              |   81.81 |      100 |   33.33 |   77.77 | 
  chatRoom.dto.ts                       |   81.81 |      100 |   33.33 |   77.77 | 5,10
 src/common/types/notification          |     100 |      100 |     100 |     100 | 
  notification.types.ts                 |     100 |      100 |     100 |     100 | 
 src/common/types/payment               |     100 |      100 |     100 |     100 | 
  payment.dto.ts                        |     100 |      100 |     100 |     100 | 
  payment.type.ts                       |     100 |      100 |     100 |     100 | 
 src/common/types/plan                  |    57.4 |        0 |       0 |   68.88 | 
  plan.dto.ts                           |    57.4 |        0 |       0 |   68.88 | 15,39,43,52-53,59,63,68,75,81,86,93,98,105
 src/common/types/pointLog              |   55.55 |      100 |       0 |   71.42 | 
  pointLog.dto.ts                       |   55.55 |      100 |       0 |   71.42 | 5,10
 src/common/types/quote                 |   56.25 |        0 |       0 |      72 | 
  quote.dto.ts                          |   56.25 |        0 |       0 |      72 | 15,20,25,32,36,41,60
 src/common/types/review                |   73.33 |      100 |       0 |   84.61 | 
  review.dto.ts                         |   73.33 |      100 |       0 |   84.61 | 25,30
 src/common/types/user                  |   85.91 |      100 |    12.5 |   92.42 | 
  login.dto.ts                          |     100 |      100 |     100 |     100 | 
  query.dto.ts                          |      60 |      100 |       0 |      75 | 8,12,18,22,26
  signup.dto.ts                         |     100 |      100 |     100 |     100 | 
  updateProfile.dto.ts                  |     100 |      100 |     100 |     100 | 
  updateUser.dto.ts                     |     100 |      100 |     100 |     100 | 
  user.response.dto.ts                  |     100 |      100 |     100 |     100 |                                                                       
  user.types.ts                         |     100 |      100 |     100 |     100 | 
 src/common/utilities                   |   41.66 |        0 |       0 |   45.45 | 
  hashingPassword.ts                    |      60 |      100 |       0 |      60 | 4,8
  validateBooleanValue.ts               |   28.57 |        0 |       0 |   33.33 | 5-8
 src/modules/auth                       |   41.87 |        0 |   13.79 |   39.33 | 
  auth.controller.ts                    |   40.62 |        0 |    8.33 |   39.34 | 34-38,48-60,66-67,74-90,96-97,104-118,124-127,134-148,158-172,179,186
  auth.module.ts                        |     100 |      100 |     100 |     100 | 
  auth.repository.ts                    |   36.36 |      100 |    12.5 |      30 | 15-70
  auth.service.ts                       |   31.66 |        0 |   22.22 |   29.82 | 25-82,93-117
 src/modules/auth/strategy              |    74.5 |        0 |    62.5 |      75 | 
  google.strategy.ts                    |   71.42 |        0 |      50 |   72.72 | 20-24
  jwt.strategy.ts                       |     100 |      100 |     100 |     100 | 
  kakao.strategy.ts                     |   66.66 |        0 |      50 |   66.66 | 19-24
  naver.strategy.ts                     |   71.42 |        0 |      50 |   72.72 | 22-26
 src/modules/chat                       |   41.17 |        0 |   21.73 |   38.52 | 
  chat.controller.ts                    |   66.66 |      100 |   33.33 |   61.53 | 12-14,21-22
  chat.module.ts                        |     100 |      100 |     100 |     100 | 
  chat.repository.ts                    |   38.23 |        0 |   14.28 |   35.48 | 20-73
  chat.service.ts                       |   26.02 |        0 |   16.66 |   24.24 | 28-140
 src/modules/chatRoom                   |   56.83 |    27.77 |   41.02 |   56.44 | 
  chatRoom.controller.ts                |   76.92 |      100 |      60 |      75 | 50-52,64-66
  chatRoom.gateway.ts                   |      48 |        0 |      25 |   45.45 | 23-38,47-48
  chatRoom.module.ts                    |     100 |      100 |     100 |     100 | 
  chatRoom.repository.ts                |    60.6 |       50 |      50 |   58.62 | 51-79
  chatRoom.service.ts                   |    44.7 |    28.57 |      35 |   46.05 | 27-42,54-55,63,81-137
 src/modules/follow                     |   54.28 |        0 |      20 |      50 | 
  follow.controller.ts                  |   83.33 |      100 |   33.33 |      80 | 13,19
  follow.module.ts                      |     100 |      100 |     100 |     100 | 
  follow.repository.ts                  |   36.84 |        0 |   14.28 |   31.25 | 12-43
  follow.service.ts                     |   41.93 |        0 |      20 |   39.28 | 23-68                                                                 
 src/modules/notification               |      53 |        0 |    12.5 |   48.86 | 
  notification.controller.ts            |   68.18 |      100 |   14.28 |      65 | 14,23,32,37,44-47
  notification.listener.ts              |   88.88 |      100 |      50 |   85.71 | 11
  notification.module.ts                |     100 |      100 |     100 |     100 | 
  notification.repository.ts            |   47.36 |      100 |   16.66 |   43.75 | 14-35
  notification.service.ts               |    27.5 |        0 |    5.88 |   24.32 | 17-71
 src/modules/payment                    |   60.24 |        0 |      25 |      56 | 
  payment.controller.ts                 |   78.57 |      100 |      25 |      75 | 16,21,26
  payment.module.ts                     |     100 |      100 |     100 |     100 | 
  payment.repository.ts                 |   56.25 |      100 |      25 |      50 | 14-29
  payment.service.ts                    |   45.23 |        0 |      25 |    42.5 | 26-73
 src/modules/plan                       |   25.17 |        0 |    7.14 |   24.42 | 
  plan.controller.ts                    |   48.88 |      100 |    8.33 |   46.51 | 21-22,31-32,41-42,47-48,58-60,66-69,79-80,90-92,97-98,104,111        
  plan.module.ts                        |     100 |      100 |     100 |     100 | 
  plan.repository.ts                    |    16.9 |        0 |    8.33 |   16.39 | 19-218
  plan.service.ts                       |   16.98 |        0 |    5.55 |   16.77 | 38-307
 src/modules/pointLog                   |   70.83 |      100 |      30 |   68.42 | 
  pointLog.controller.ts                |      90 |      100 |      50 |    87.5 | 13
  pointLog.module.ts                    |     100 |      100 |     100 |     100 | 
  pointLog.repository.ts                |   56.25 |      100 |      25 |   53.84 | 14-24
  pointLog.service.ts                   |   53.84 |      100 |      25 |      50 | 12-21
 src/modules/quote                      |   33.74 |        0 |   11.53 |   32.86 | 
  quote.controller.ts                   |   63.63 |      100 |      20 |      60 | 20-22,31-32,41-42,48
  quote.module.ts                       |     100 |      100 |     100 |     100 | 
  quote.repository.ts                   |   16.07 |        0 |    9.09 |      14 | 14-175
  quote.service.ts                      |   29.33 |        0 |      10 |   30.76 | 32-131
 src/modules/review                     |   54.87 |        0 |   17.64 |   52.85 | 
  review.controller.ts                  |   81.25 |      100 |      25 |   78.57 | 18,27,33
  review.module.ts                      |     100 |      100 |     100 |     100 | 
  review.repository.ts                  |   26.92 |        0 |   14.28 |   22.72 | 13-65
  review.service.ts                     |   51.61 |        0 |   16.66 |   51.85 | 22-65
 src/modules/task                       |   77.77 |      100 |      25 |   73.91 |                                                                       
  task.module.ts                        |     100 |      100 |     100 |     100 | 
  tasks.service.ts                      |   68.42 |      100 |      25 |    64.7 | 18-29
 src/modules/user                       |    53.9 |    18.51 |   26.66 |   51.69 | 
  user.controller.ts                    |   70.96 |       40 |    12.5 |   68.96 | 38,50,56,65,71,81,95-98
  user.module.ts                        |     100 |      100 |     100 |     100 | 
  user.repository.ts                    |   48.71 |    11.11 |   36.36 |   47.22 | 24-99,127-145
  user.service.ts                       |   38.77 |       25 |   27.27 |   36.95 | 44-117
 src/modules/userStats                  |   51.06 |        0 |      25 |    43.9 | 
  userStats.module.ts                   |     100 |      100 |     100 |     100 | 
  userStats.repository.ts               |   53.84 |      100 |      25 |   45.45 | 12-26
  userStats.service.ts                  |   37.03 |        0 |      25 |      32 | 17-49
 src/providers/cache                    |      64 |        0 |      40 |   57.14 | 
  redis.module.ts                       |      90 |      100 |      50 |    87.5 | 13
  redis.service.ts                      |   46.66 |        0 |   33.33 |   38.46 | 13-35
 src/providers/database/mongoose        |   97.59 |      100 |   66.66 |   97.26 | 
  chat.schema.ts                        |     100 |      100 |     100 |     100 | 
  chatRoom.schema.ts                    |     100 |      100 |     100 |     100 | 
  mongoose.seed.ts                      |    87.5 |      100 |   66.66 |    87.5 | 24-25
  notification.schema.ts                |     100 |      100 |     100 |     100 | 
  payment.schema.ts                     |     100 |      100 |     100 |     100 | 
  pointLog.schema.ts                    |     100 |      100 |     100 |     100 | 
 src/providers/database/mongoose/config |     100 |      100 |     100 |     100 | 
  mongo.config.ts                       |     100 |      100 |     100 |     100 | 
 src/providers/database/mongoose/mock   |     100 |       50 |     100 |     100 | 
  chatRoom.mock.ts                      |     100 |       50 |     100 |     100 | 118
 src/providers/database/prisma          |   38.23 |        0 |      25 |   32.25 | 
  DB.client.ts                          |   27.58 |        0 |      25 |      25 | 13-64
  prisma.module.ts                      |     100 |      100 |     100 |     100 | 
 src/providers/database/prisma/mock     |     100 |      100 |     100 |     100 | 
  test.mock.ts                          |     100 |      100 |     100 |     100 | 
 src/providers/pg                       |   72.72 |      100 |      60 |   66.66 | 
  pg.module.ts                          |     100 |      100 |     100 |     100 | 
  pg.service.ts                         |   57.14 |      100 |   33.33 |      50 | 12-23
  bullmq.module.ts                      |     100 |      100 |     100 |     100 | 
  points.processor.ts                   |   33.33 |        0 |    12.5 |   33.33 | 18-45
  userStats.processor.ts                |   38.23 |        0 |   33.33 |   34.37 | 21-60
 src/providers/storage/s3               |   55.26 |        0 |      60 |   51.51 | 
  s3.config.ts                          |     100 |      100 |     100 |     100 | 
  s3.module.ts                          |     100 |      100 |     100 |     100 | 
  s3.service.ts                         |   39.28 |        0 |   33.33 |      36 | 15-51
----------------------------------------|---------|----------|---------|---------|-----------------------------------------------------------------------
Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
Snapshots:   0 total
