### PR TITLE
Follow 모듈 e2e 테스트 코드

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,13 @@
     "test:e2e": "jest --config ./jest-e2e.json",
     "test:e2e:plan": "jest src/modules/plan/plan.e2e.spec.ts --detectOpenHandles --coverage",
     "test:e2e:quote": "jest src/modules/quote/quote.e2e.spec.ts --detectOpenHandles --coverage",
-    "test:e2e:auth": "jest src/modules/auth/auth.e2e.spec.ts --detectOpenHandles",
-    "test:e2e:chatRoom": "jest src/modules/chatRoom/chatRoom.e2e.spec.ts --detectOpenHandles --coverage"
-    "test:e2e:review": "jest src/modules/review/review.e2e.spec.ts --detectOpenHandles"
+    "test:e2e:auth": "jest src/modules/auth/auth.e2e.spec.ts --detectOpenHandles --coverage",
+    "test:e2e:user": "jest src/modules/user/user.e2e.spec.ts --detectOpenHandles --coverage",
+    "test:e2e:follow": "jest src/modules/follow/follow.e2e.spec.ts --detectOpenHandles --coverage",
+    "test:e2e:notification": "jest src/modules/notification/notification.e2e.spec.ts --detectOpenHandles --coverage",
+    "test:e2e:payment": "jest src/modules/payment/payment.e2e.spec.ts --detectOpenHandles --coverage",
+    "test:e2e:chatRoom": "jest src/modules/chatRoom/chatRoom.e2e.spec.ts --detectOpenHandles --coverage",
+    "test:e2e:review": "jest src/modules/review/review.e2e.spec.ts --detectOpenHandles --coverage"
   },
   "prisma": {
     "schema": "src/providers/database/prisma/schema.prisma"

--- a/src/modules/follow/follow.controller.ts
+++ b/src/modules/follow/follow.controller.ts
@@ -4,16 +4,17 @@ import { UserId } from 'src/common/decorators/user.decorator';
 import { Role } from 'src/common/decorators/roleGuard.decorator';
 
 @Controller('follow')
-@Role('DREAMER')
 export default class FollowController {
   constructor(private readonly service: FollowService) {}
   @Post()
+  @Role('DREAMER')
   @HttpCode(HttpStatus.NO_CONTENT)
   async follow(@UserId() dreamerId: string, @Body('makerId') makerId: string): Promise<null> {
     return await this.service.create(dreamerId, makerId);
   }
 
   @Delete()
+  @Role('DREAMER')
   @HttpCode(HttpStatus.NO_CONTENT)
   async unfollow(@UserId() dreamerId: string, @Body('makerId') makerId: string): Promise<null> {
     return await this.service.delete(dreamerId, makerId);

--- a/src/modules/follow/follow.e2e.spec.ts
+++ b/src/modules/follow/follow.e2e.spec.ts
@@ -1,0 +1,106 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpStatus, INestApplication, ValidationPipe } from '@nestjs/common';
+import request from 'supertest';
+import AppModule from 'src/app.module';
+import GlobalExceptionFilter from 'src/common/filters/globalExceptionFilter';
+import DBClient from 'src/providers/database/prisma/DB.client';
+import { RoleValues } from 'src/common/constants/role.type';
+import AuthService from '../auth/auth.service';
+
+describe('Review Test (e2e)', () => {
+  let app: INestApplication;
+
+  const makerId = process.env.MAKER1_ID;
+  const dreamerId = process.env.DREAMER1_ID;
+
+  let makerToken: string;
+  let dreamerToken: string;
+
+  jest.setTimeout(100000);
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule]
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ transform: true })).useGlobalFilters(new GlobalExceptionFilter());
+    await app.init();
+
+    const prismaDB = app.get<DBClient>(DBClient);
+    const authService = app.get<AuthService>(AuthService);
+
+    await prismaDB.seedForTestEnvironment();
+    dreamerToken = authService.createTokens({ userId: dreamerId, role: RoleValues.DREAMER }).accessToken;
+    makerToken = authService.createTokens({ userId: makerId, role: RoleValues.MAKER }).accessToken;
+  });
+
+  afterAll(async () => {
+    const prismaDB = app.get<DBClient>(DBClient);
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    await prismaDB.$disconnect();
+    await app.close();
+  });
+
+  describe('[POST /follow]', () => {
+    const dto = { makerId };
+
+    it('찜하기', async () => {
+      const { statusCode } = await request(app.getHttpServer())
+        .post('/follow')
+        .set('authorization', `Bearer ${dreamerToken}`)
+        .send(dto);
+
+      expect(statusCode).toBe(HttpStatus.NO_CONTENT);
+    });
+
+    it('찜하기, 이미 찜한 MAKER인 경우 400에러', async () => {
+      const { statusCode } = await request(app.getHttpServer())
+        .post('/follow')
+        .set('authorization', `Bearer ${dreamerToken}`)
+        .send(dto);
+
+      expect(statusCode).toBe(HttpStatus.BAD_REQUEST);
+    });
+
+    it('찜하기, DREAMER가 아닌 경우 403에러', async () => {
+      const { statusCode } = await request(app.getHttpServer())
+        .post('/follow')
+        .set('authorization', `Bearer ${makerToken}`)
+        .send(dto);
+
+      expect(statusCode).toBe(HttpStatus.FORBIDDEN);
+    });
+  });
+
+  describe('[DELETE /follow]', () => {
+    const dto = { makerId };
+
+    it('찜 취소하기', async () => {
+      const { statusCode } = await request(app.getHttpServer())
+        .delete('/follow')
+        .set('authorization', `Bearer ${dreamerToken}`)
+        .send(dto);
+
+      expect(statusCode).toBe(HttpStatus.NO_CONTENT);
+    });
+
+    it('찜 취소하기, 찜한 MAKER가 아닌 경우 400에러', async () => {
+      const { statusCode } = await request(app.getHttpServer())
+        .delete('/follow')
+        .set('authorization', `Bearer ${dreamerToken}`)
+        .send(dto);
+
+      expect(statusCode).toBe(HttpStatus.BAD_REQUEST);
+    });
+
+    it('찜 취소하기, DREAMER가 아닌 경우 403에러', async () => {
+      const { statusCode } = await request(app.getHttpServer())
+        .delete('/follow')
+        .set('authorization', `Bearer ${makerToken}`)
+        .send(dto);
+
+      expect(statusCode).toBe(HttpStatus.FORBIDDEN);
+    });
+  });
+});


### PR DESCRIPTION
## 작업한 이슈 번호

- close #227 

## 작업 사항 설명

Follow 모듈 테스트 코드 구현

## 작업 사항

- [x] Follow 모듈 테스트 코드 구현

## 기타

- followRepository와 followService의 테스트 커버리지가 낮은 이유는 follow 목록은 유저를 기반으로 조회하기 때문에 userController에 있어서 userModule에서 검사합니다.

| File | $ Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s |
|--|--|--|--|--|--|
 src/modules/follow                     |   85.71 |      100 |   66.66 |   86.66 |                                     
  follow.controller.ts                  |     100 |      100 |     100 |     100 |                                     
  follow.module.ts                      |     100 |      100 |     100 |     100 |                                     
  follow.repository.ts                  |   73.68 |      100 |   57.14 |      75 | 12-23                               
  follow.service.ts                     |   83.87 |      100 |      60 |   85.71 | 23-28 