### PR TITLE
Notification 모듈 e2e 테스트 코드

### DIFF
--- a/src/common/domains/notification/notification.mapper.ts
+++ b/src/common/domains/notification/notification.mapper.ts
@@ -1,12 +1,14 @@
-import { NotificationProperties } from 'src/common/types/notification/notification.types';
 import Notification from './notification.domain';
+import { NotificationDocument } from 'src/providers/database/mongoose/notification.schema';
 
 export default class NotificationMapper {
-  constructor(private readonly notification: NotificationProperties) {}
+  constructor(private readonly notification: NotificationDocument) {}
 
   toDomain() {
+    if (!this.notification) return null;
+
     return new Notification({
-      id: this.notification.id,
+      id: this.notification._id.toString(),
       userId: this.notification.userId,
       event: this.notification.event,
       payload: this.notification.payload,

--- a/src/modules/notification/notification.controller.ts
+++ b/src/modules/notification/notification.controller.ts
@@ -38,7 +38,6 @@ export default class NotificationController {
   }
 
   // 로그인 시 알림 SSE stream 연결 요청
-  @Public()
   @Sse('stream')
   stream(@UserId() userId: string): Observable<{ data: string }> {
     console.log(`SSE connection for userId: ${userId}`);

--- a/src/modules/notification/notification.e2e.spec.ts
+++ b/src/modules/notification/notification.e2e.spec.ts
@@ -1,0 +1,82 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpStatus, INestApplication, ValidationPipe } from '@nestjs/common';
+import request from 'supertest';
+import AppModule from 'src/app.module';
+import GlobalExceptionFilter from 'src/common/filters/globalExceptionFilter';
+import { RoleValues } from 'src/common/constants/role.type';
+import AuthService from '../auth/auth.service';
+import { seed } from 'src/providers/database/mongoose/mongoose.seed';
+
+describe('Notification Test (e2e)', () => {
+  let app: INestApplication;
+
+  const dreamerId = process.env.DREAMER1_ID;
+  const notificationId = process.env.NOTIFICATION_ID;
+
+  let dreamerToken: string;
+
+  jest.setTimeout(100000);
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule]
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ transform: true })).useGlobalFilters(new GlobalExceptionFilter());
+    await app.init();
+
+    const authService = app.get<AuthService>(AuthService);
+    await seed();
+
+    dreamerToken = authService.createTokens({ userId: dreamerId, role: RoleValues.DREAMER }).accessToken;
+  });
+
+  afterAll(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    await app.close();
+  });
+
+  describe('[GET /notifications]', () => {
+    it('나의 알림 목록 조회', async () => {
+      const { body, statusCode } = await request(app.getHttpServer())
+        .get('/notifications')
+        .set('authorization', `Bearer ${dreamerToken}`);
+
+      expect(statusCode).toBe(HttpStatus.OK);
+      expect(body).toBeDefined();
+    });
+
+    it('나의 채팅방 목록 조회, 비로그인 요청인 경우 401에러', async () => {
+      const { statusCode } = await request(app.getHttpServer()).get('/notifications');
+
+      expect(statusCode).toBe(HttpStatus.UNAUTHORIZED);
+    });
+  });
+
+  describe('[PATCH /notifications/{notificationId}]', () => {
+    it('알림 읽음 처리', async () => {
+      const { statusCode } = await request(app.getHttpServer())
+        .patch(`/notifications/${notificationId}`)
+        .set('authorization', `Bearer ${dreamerToken}`);
+
+      expect(statusCode).toBe(HttpStatus.OK);
+    });
+
+    it('알림 읽음 처리, 이미 읽은 알림인 경우 403에러', async () => {
+      const { statusCode } = await request(app.getHttpServer())
+        .patch(`/notifications/${notificationId}`)
+        .set('authorization', `Bearer ${dreamerToken}`);
+
+      expect(statusCode).toBe(HttpStatus.OK);
+    });
+
+    it('알림 읽음 처리, 존재하지 않는 알림 ID인 경우 400에러', async () => {
+      const { statusCode } = await request(app.getHttpServer())
+        .patch(`/notifications/67918968c27c4c4cfe5c47ff`)
+        .set('authorization', `Bearer ${dreamerToken}`);
+
+      expect(statusCode).toBe(HttpStatus.BAD_REQUEST);
+    });
+  });
+});

--- a/src/modules/notification/notification.repository.ts
+++ b/src/modules/notification/notification.repository.ts
@@ -18,9 +18,8 @@ export default class NotificationRepository {
 
   async findById(id: string): Promise<INotification> {
     const notification = await this.notification.findById(id).exec();
-    const data = { ...notification.toObject(), id: notification._id.toString() };
 
-    return new NotificationMapper(data).toDomain();
+    return new NotificationMapper(notification).toDomain();
   }
 
   async create(data: NotificationProperties): Promise<INotification> {

--- a/src/providers/database/mongoose/mock/notification.mock.ts
+++ b/src/providers/database/mongoose/mock/notification.mock.ts
@@ -1,0 +1,16 @@
+import 'dotenv/config';
+
+const TEST_NOTIFICATIONS = [
+  {
+    _id: '67918968c27c4c4cfe5c47fe',
+    isDeletedAt: null,
+    userId: '66885a3c-50f4-427b-8a92-3702c6976fb0',
+    event: 'ARRIVE_REQUEST',
+    payload: { nickName: '호랑이', tripType: 'FOOD_TOUR' },
+    isRead: false
+  }
+];
+const PRODUCTION_NOTIFICATIONS = [{}];
+
+const NOTIFICATIONS = process.env.ENV === 'test' ? TEST_NOTIFICATIONS : PRODUCTION_NOTIFICATIONS;
+export default NOTIFICATIONS;

--- a/src/providers/database/mongoose/mongoose.seed.ts
+++ b/src/providers/database/mongoose/mongoose.seed.ts
@@ -1,8 +1,10 @@
+import 'dotenv/config';
 import mongoose from 'mongoose';
 import { ChatRoomModel } from './chatRoom.schema';
 import { ChatModel } from './chat.schema';
 import CHAT_ROOMS from './mock/chatRoom.mock';
-import 'dotenv/config';
+import { NotificationModel } from './notification.schema';
+import NOTIFICATIONS from './mock/notification.mock';
 
 async function connectDB() {
   await mongoose.connect(process.env.MONGO_URI);
@@ -13,8 +15,10 @@ export async function seed() {
 
   await ChatModel.deleteMany();
   await ChatRoomModel.deleteMany();
+  await NotificationModel.deleteMany();
 
   await ChatRoomModel.insertMany(CHAT_ROOMS);
+  await NotificationModel.insertMany(NOTIFICATIONS);
 
   console.log('🌱 Mongoose Seeding completed!');
   mongoose.connection.close();

--- a/src/providers/database/mongoose/notification.schema.ts
+++ b/src/providers/database/mongoose/notification.schema.ts
@@ -1,5 +1,5 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
-import { HydratedDocument, Types } from 'mongoose';
+import mongoose, { HydratedDocument, Types } from 'mongoose';
 import { NotificationEvent } from 'src/common/types/notification/notification.types';
 
 @Schema({ timestamps: true })
@@ -19,7 +19,9 @@ export class Notification {
   @Prop({ default: false })
   isRead: boolean;
 }
-export type NotificationDocument = HydratedDocument<Notification>;
+export type NotificationDocument = HydratedDocument<Notification> & { createdAt?: Date; updatedAt?: Date };
 
 const NotificationSchema = SchemaFactory.createForClass(Notification);
+export const NotificationModel = mongoose.model('Notification', NotificationSchema);
+
 export default NotificationSchema;


### PR DESCRIPTION
## 작업한 이슈 번호

- close #228 

## 작업 사항 설명

Notification 모듈 테스트 코드 구현

## 작업 사항

- [x] Notification 모듈 테스트 코드 구현

## 기타

- 알림의 경우 생성을 내부에서 진행하기 때문에 다른 모듈에서 테스트 되기 때문에 이번 커버리지가 낮습니다. controller의 경우 sse 연결 테스트는 생략했습니다. 참고해주세요.

| File | $ Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s |
|--|--|--|--|--|--|
src/modules/notification               |   71.42 |      100 |   40.62 |   67.44 |                                                                
  notification.controller.ts            |   76.19 |      100 |   42.85 |   73.68 | 14,23,43-46                                                    
  notification.listener.ts              |   88.88 |      100 |      50 |   85.71 | 11                                                             
  notification.module.ts                |     100 |      100 |     100 |     100 |                                                                
  notification.repository.ts            |   88.88 |      100 |   83.33 |   86.66 | 26-28                                                          
  notification.service.ts               |      50 |      100 |   23.52 |   45.94 | 23-28,43-71