### PR TITLE
지정견적 리스트는 메이커의 지역과 상관 없이 필터되지 않도록 수정

### DIFF
--- a/src/common/constants/errorMessage.enum.ts
+++ b/src/common/constants/errorMessage.enum.ts
@@ -37,7 +37,7 @@ export enum ErrorMessage {
   PLAN_READY_TO_REVIEW_BAD_REQUEST = '완료할 수 있는 플랜 필터링은 CONFIRMED 상태만 가능합니다.',
   PLAN_REVIEW_FILTER_BAD_REQUEST = '리뷰는 OVERDUE와 PENDING 상태의 플랜에는 있을 수 없습니다.',
   PLAN_DELETE_BAD_REQUEST = 'CONFIRMED 상태의 진행중인 플랜은 삭제할 수 없습니다.',
-  PLAN_IS_ASSIGNED_BAD_REQUEST = 'IS_ASSIGNED 값은 true와 false 혹은 입력하지 않아야 합니다.',
+  PLAN_IS_ASSIGNED_BAD_REQUEST = 'isAssigned 쿼리의 값은 true와 false 혹은 쿼리를입력하지 않아야 합니다.',
   PLAN_CANNOT_CREATE_CHATROOM_BAD_REQUEST = '해당 플랜은 채팅방을 만들 수 없습니다. CONFIRMED상태의 플랜만 가능합니다.',
   PLAN_MAKER_NOT_IN_SERVICE_AREA = '메이커의 서비스지역이 플랜의 서비스지역과 일치하지 않습니다.',
 

--- a/src/modules/plan/plan.service.ts
+++ b/src/modules/plan/plan.service.ts
@@ -55,8 +55,7 @@ export default class PlanService {
     options: PlanQueryOptions
   ): Promise<{ totalCount: number; groupByCount: GroupByCount; list: PlanToClientProperties[] }> {
     const makerProfile = await this.userService.getProfile(RoleValues.MAKER, userId);
-
-    const serviceArea: ServiceArea[] = makerProfile.serviceArea;
+    const serviceArea: ServiceArea[] = options.isAssigned === true ? undefined : makerProfile.serviceArea;
 
     options.serviceArea = serviceArea; //NOTE. 메이커의 서비스지역 필터링
     options.userId = userId;


### PR DESCRIPTION
## 작업한 이슈 번호

- close #254 

## 작업 사항 설명

서비스 지역이 다른 메이커에게는 지정견적을 신청하지 못하도록 막아둔건 그대로 유지중.
가정하는 상황은 "지정견적 요청을 받은 이후 메이커가 서비스지역을 수정할 경우 지정견적요청은 그래도 보여야한다."
이 상황을 위해 수정

## 작업 사항

- [x] 지정견적 리스트는 메이커의 지역과 상관 없이 필터되지 않도록 수정

## 기타

- 
