### PR TITLE
토큰 set cookie 설정 수정

### DIFF
--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -52,7 +52,7 @@ export default class AuthController {
     res.cookie('refreshToken', refreshToken, {
       path: '/user/token/refresh',
       httpOnly: true,
-      sameSite: 'none',
+      sameSite: 'lax',
       secure: true,
       maxAge: 7 * 24 * 60 * 60 * 1000
     });
@@ -82,7 +82,7 @@ export default class AuthController {
     res.cookie('refreshToken', tokens.refreshToken, {
       path: '/user/token/refresh',
       httpOnly: true,
-      sameSite: 'none',
+      sameSite: 'lax',
       secure: true,
       maxAge: 7 * 24 * 60 * 60 * 1000
     });
@@ -110,7 +110,7 @@ export default class AuthController {
     res.cookie('refreshToken', tokens.refreshToken, {
       path: '/user/token/refresh',
       httpOnly: true,
-      sameSite: 'none',
+      sameSite: 'lax',
       secure: true,
       maxAge: 7 * 24 * 60 * 60 * 1000
     });
@@ -140,7 +140,7 @@ export default class AuthController {
     res.cookie('refreshToken', tokens.refreshToken, {
       path: '/user/token/refresh',
       httpOnly: true,
-      sameSite: 'none',
+      sameSite: 'lax',
       secure: true,
       maxAge: 7 * 24 * 60 * 60 * 1000
     });
@@ -164,7 +164,7 @@ export default class AuthController {
     res.cookie('refreshToken', newRefreshToken, {
       path: '/user/token/refresh',
       httpOnly: true,
-      sameSite: 'none',
+      sameSite: 'lax',
       secure: true,
       maxAge: 7 * 24 * 60 * 60 * 1000
     });


### PR DESCRIPTION
## 작업한 이슈 번호

- close #259 

## 작업 사항 설명

프론트엔드와의 프록시 설정에 맞게 refreshToken을 브라우저 쿠키 저장할 때 보안 설정을 수정합니다.

## 작업 사항

- [x] sameSite: none -> lax

## 기타

- 
